### PR TITLE
Adding service port naming

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -55,7 +55,7 @@ Each `RuntimeComponent` CR must at least specify the `applicationImage` paramete
 | `initContainers` | The list of [Init Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#container-v1-core) definitions. |
 | `architecture` | An array of architectures to be considered for deployment. Their position in the array indicates preference. |
 | `service.port` | The port exposed by the container. |
-| `service.port.name` | The name for the port exposed by the container. |
+| `service.portName` | The name for the port exposed by the container. |
 | `service.type` | The Kubernetes [Service Type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | `service.annotations` | Annotations to be added to the service. |
 | `service.certificate` | A YAML object representing a [Certificate](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1alpha2.CertificateSpec). |

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -55,6 +55,7 @@ Each `RuntimeComponent` CR must at least specify the `applicationImage` paramete
 | `initContainers` | The list of [Init Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#container-v1-core) definitions. |
 | `architecture` | An array of architectures to be considered for deployment. Their position in the array indicates preference. |
 | `service.port` | The port exposed by the container. |
+| `service.port.name` | The name for the port exposed by the container. |
 | `service.type` | The Kubernetes [Service Type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | `service.annotations` | Annotations to be added to the service. |
 | `service.certificate` | A YAML object representing a [Certificate](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1alpha2.CertificateSpec). |

--- a/pkg/apis/appstacks/v1beta1/runtimecomponent_types.go
+++ b/pkg/apis/appstacks/v1beta1/runtimecomponent_types.go
@@ -68,7 +68,7 @@ type RuntimeComponentService struct {
 	// +kubebuilder:validation:Minimum=1
 	Port int32 `json:"port,omitempty"`
 
-	Name string `json:"name,omitempty"`
+	PortName string `json:"portName,omitempty"`
 
 	Annotations map[string]string `json:"annotations,omitempty"`
 	// +listType=atomic
@@ -398,9 +398,9 @@ func (s *RuntimeComponentService) GetPort() int32 {
 	return s.Port
 }
 
-// GetName returns service name
-func (s *RuntimeComponentService) GetName() string {
-	return s.Name
+// GetPortName returns name of service port
+func (s *RuntimeComponentService) GetPortName() string {
+	return s.PortName
 }
 
 // GetType returns service type

--- a/pkg/apis/appstacks/v1beta1/runtimecomponent_types.go
+++ b/pkg/apis/appstacks/v1beta1/runtimecomponent_types.go
@@ -68,6 +68,8 @@ type RuntimeComponentService struct {
 	// +kubebuilder:validation:Minimum=1
 	Port int32 `json:"port,omitempty"`
 
+	Name string `json:"name,omitempty"`
+
 	Annotations map[string]string `json:"annotations,omitempty"`
 	// +listType=atomic
 	Consumes []ServiceBindingConsumes `json:"consumes,omitempty"`
@@ -394,6 +396,11 @@ func (s *RuntimeComponentService) GetAnnotations() map[string]string {
 // GetPort returns service port
 func (s *RuntimeComponentService) GetPort() int32 {
 	return s.Port
+}
+
+// GetName returns service name
+func (s *RuntimeComponentService) GetName() string {
+	return s.Name
 }
 
 // GetType returns service type

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -72,7 +72,7 @@ type BaseApplicationStorage interface {
 // BaseApplicationService represents basic service configuration
 type BaseApplicationService interface {
 	GetPort() int32
-	GetName() string
+	GetPortName() string
 	GetType() *corev1.ServiceType
 	GetAnnotations() map[string]string
 	GetProvides() ServiceBindingProvides

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -72,6 +72,7 @@ type BaseApplicationStorage interface {
 // BaseApplicationService represents basic service configuration
 type BaseApplicationService interface {
 	GetPort() int32
+	GetName() string
 	GetType() *corev1.ServiceType
 	GetAnnotations() map[string]string
 	GetProvides() ServiceBindingProvides

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -155,7 +155,12 @@ func CustomizeService(svc *corev1.Service, ba common.BaseApplication) {
 
 	svc.Spec.Ports[0].Port = ba.GetService().GetPort()
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(ba.GetService().GetPort()))
-	svc.Spec.Ports[0].Name = strconv.Itoa(int(ba.GetService().GetPort())) + "-tcp"
+	// svc.Spec.Ports[0].Name = strconv.Itoa(int(ba.GetService().GetPort())) + "-tcp"
+	if ba.GetService().GetName() != "" {
+		svc.Spec.Ports[0].Name = ba.GetService().GetName()
+	} else {
+		svc.Spec.Ports[0].Name = strconv.Itoa(int(ba.GetService().GetPort())) + "-tcp"
+	}
 	svc.Spec.Type = *ba.GetService().GetType()
 	svc.Spec.Selector = map[string]string{
 		"app.kubernetes.io/instance": obj.GetName(),

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -155,9 +155,9 @@ func CustomizeService(svc *corev1.Service, ba common.BaseApplication) {
 
 	svc.Spec.Ports[0].Port = ba.GetService().GetPort()
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(ba.GetService().GetPort()))
-	// svc.Spec.Ports[0].Name = strconv.Itoa(int(ba.GetService().GetPort())) + "-tcp"
-	if ba.GetService().GetName() != "" {
-		svc.Spec.Ports[0].Name = ba.GetService().GetName()
+
+	if ba.GetService().GetPortName() != "" {
+		svc.Spec.Ports[0].Name = ba.GetService().GetPortName()
 	} else {
 		svc.Spec.Ports[0].Name = strconv.Itoa(int(ba.GetService().GetPort())) + "-tcp"
 	}


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Adds support to specify names for service ports
- Allows user to specify "service.port.name" field instead of always hardcoding the port name

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [x] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #28 
