### PR TITLE
Add certificate secret reference property

### DIFF
--- a/deploy/crds/app.stacks_runtimecomponents_crd.yaml
+++ b/deploy/crds/app.stacks_runtimecomponents_crd.yaml
@@ -1976,6 +1976,8 @@ spec:
                         type: string
                       type: array
                   type: object
+                certificateSecretRef:
+                  type: string
                 host:
                   type: string
                 insecureEdgeTerminationPolicy:
@@ -2129,6 +2131,8 @@ spec:
                         type: string
                       type: array
                   type: object
+                certificateSecretRef:
+                  type: string
                 consumes:
                   items:
                     description: ServiceBindingConsumes represents a service to be

--- a/pkg/apis/appstacks/v1beta1/runtimecomponent_types.go
+++ b/pkg/apis/appstacks/v1beta1/runtimecomponent_types.go
@@ -73,7 +73,8 @@ type RuntimeComponentService struct {
 	Consumes []ServiceBindingConsumes `json:"consumes,omitempty"`
 	Provides *ServiceBindingProvides  `json:"provides,omitempty"`
 	// +k8s:openapi-gen=true
-	Certificate *Certificate `json:"certificate,omitempty"`
+	Certificate          *Certificate `json:"certificate,omitempty"`
+	CertificateSecretRef *string      `json:"certificateSecretRef,omitempty"`
 }
 
 // ServiceBindingProvides represents information about
@@ -116,6 +117,7 @@ type RuntimeComponentRoute struct {
 	Termination                   *routev1.TLSTerminationType                `json:"termination,omitempty"`
 	InsecureEdgeTerminationPolicy *routev1.InsecureEdgeTerminationPolicyType `json:"insecureEdgeTerminationPolicy,omitempty"`
 	Certificate                   *Certificate                               `json:"certificate,omitempty"`
+	CertificateSecretRef          *string                                    `json:"certificateSecretRef,omitempty"`
 	Host                          string                                     `json:"host,omitempty"`
 	Path                          string                                     `json:"path,omitempty"`
 }
@@ -417,6 +419,11 @@ func (s *RuntimeComponentService) GetCertificate() common.Certificate {
 	return s.Certificate
 }
 
+// GetCertificateSecretRef returns a secret reference with a certificate
+func (s *RuntimeComponentService) GetCertificateSecretRef() *string {
+	return s.CertificateSecretRef
+}
+
 // GetCategory returns category of a service provider configuration
 func (p *ServiceBindingProvides) GetCategory() common.ServiceBindingCategory {
 	return p.Category
@@ -500,6 +507,11 @@ func (r *RuntimeComponentRoute) GetCertificate() common.Certificate {
 		return nil
 	}
 	return r.Certificate
+}
+
+// GetCertificateSecretRef returns a secret reference with a certificate
+func (r *RuntimeComponentRoute) GetCertificateSecretRef() *string {
+	return r.CertificateSecretRef
 }
 
 // GetTermination returns terminatation of the route's TLS

--- a/pkg/apis/appstacks/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/appstacks/v1beta1/zz_generated.deepcopy.go
@@ -208,6 +208,11 @@ func (in *RuntimeComponentRoute) DeepCopyInto(out *RuntimeComponentRoute) {
 		*out = new(Certificate)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CertificateSecretRef != nil {
+		in, out := &in.CertificateSecretRef, &out.CertificateSecretRef
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -250,6 +255,11 @@ func (in *RuntimeComponentService) DeepCopyInto(out *RuntimeComponentService) {
 		in, out := &in.Certificate, &out.Certificate
 		*out = new(Certificate)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.CertificateSecretRef != nil {
+		in, out := &in.CertificateSecretRef, &out.CertificateSecretRef
+		*out = new(string)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/appstacks/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/appstacks/v1beta1/zz_generated.openapi.go
@@ -136,6 +136,12 @@ func schema_pkg_apis_appstacks_v1beta1_RuntimeComponentRoute(ref common.Referenc
 							Ref: ref("./pkg/apis/appstacks/v1beta1.Certificate"),
 						},
 					},
+					"certificateSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"host": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -214,6 +220,12 @@ func schema_pkg_apis_appstacks_v1beta1_RuntimeComponentService(ref common.Refere
 					"certificate": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("./pkg/apis/appstacks/v1beta1.Certificate"),
+						},
+					},
+					"certificateSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -77,6 +77,7 @@ type BaseApplicationService interface {
 	GetProvides() ServiceBindingProvides
 	GetConsumes() []ServiceBindingConsumes
 	GetCertificate() Certificate
+	GetCertificateSecretRef() *string
 }
 
 // BaseApplicationMonitoring represents basic service monitoring configuration
@@ -93,6 +94,7 @@ type BaseApplicationRoute interface {
 	GetAnnotations() map[string]string
 	GetHost() string
 	GetPath() string
+	GetCertificateSecretRef() *string
 }
 
 // ServiceBindingProvides represents a service to be provided

--- a/pkg/utils/reconciler.go
+++ b/pkg/utils/reconciler.go
@@ -530,7 +530,9 @@ func (r *ReconcilerBase) ReconcileCertificate(ba common.BaseApplication) (reconc
 					crt.Spec.RenewBefore = &metav1.Duration{Duration: time.Hour * 24 * 31}
 				}
 				crt.Spec.CommonName = obj.GetName() + "." + obj.GetNamespace() + "." + "svc"
-				crt.Spec.SecretName = obj.GetName() + "-svc-tls"
+				if crt.Spec.SecretName == "" {
+					crt.Spec.SecretName = obj.GetName() + "-svc-tls"
+				}
 				if len(crt.Spec.DNSNames) == 0 {
 					crt.Spec.DNSNames = append(crt.Spec.DNSNames, crt.Spec.CommonName)
 				}
@@ -580,7 +582,9 @@ func (r *ReconcilerBase) ReconcileCertificate(ba common.BaseApplication) (reconc
 				if crt.Spec.RenewBefore == nil {
 					crt.Spec.RenewBefore = &metav1.Duration{Duration: time.Hour * 24 * 31}
 				}
-				crt.Spec.SecretName = obj.GetName() + "-route-tls"
+				if crt.Spec.SecretName == "" {
+					crt.Spec.SecretName = obj.GetName() + "-route-tls"
+				}
 				// use routes host if no DNS information provided on certificate
 				if crt.Spec.CommonName == "" {
 					crt.Spec.CommonName = ba.GetRoute().GetHost()
@@ -638,9 +642,16 @@ func (r *ReconcilerBase) IsOpenShift() bool {
 func (r *ReconcilerBase) GetRouteTLSValues(ba common.BaseApplication) (key string, cert string, ca string, destCa string, err error) {
 	key, cert, ca, destCa = "", "", "", ""
 	mObj := ba.(metav1.Object)
-	if ba.GetService() != nil && ba.GetService().GetCertificate() != nil {
+	if ba.GetService() != nil && (ba.GetService().GetCertificate() != nil || ba.GetService().GetCertificateSecretRef() != nil) {
 		tlsSecret := &corev1.Secret{}
-		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: mObj.GetName() + "-svc-tls", Namespace: mObj.GetNamespace()}, tlsSecret)
+		secretName := mObj.GetName() + "-svc-tls"
+		if ba.GetService().GetCertificate() != nil && ba.GetService().GetCertificate().GetSpec().SecretName != "" {
+			secretName = ba.GetService().GetCertificate().GetSpec().SecretName
+		}
+		if ba.GetService().GetCertificateSecretRef() != nil {
+			secretName = *ba.GetService().GetCertificateSecretRef()
+		}
+		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: mObj.GetNamespace()}, tlsSecret)
 		if err != nil {
 			r.ManageError(err, common.StatusConditionTypeReconciled, ba)
 			return "", "", "", "", err
@@ -650,9 +661,16 @@ func (r *ReconcilerBase) GetRouteTLSValues(ba common.BaseApplication) (key strin
 			destCa = string(caCrt)
 		}
 	}
-	if ba.GetRoute() != nil && ba.GetRoute().GetCertificate() != nil {
+	if ba.GetRoute() != nil && (ba.GetRoute().GetCertificate() != nil || ba.GetRoute().GetCertificateSecretRef() != nil) {
 		tlsSecret := &corev1.Secret{}
-		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: mObj.GetName() + "-route-tls", Namespace: mObj.GetNamespace()}, tlsSecret)
+		secretName := mObj.GetName() + "-route-tls"
+		if ba.GetRoute().GetCertificate() != nil && ba.GetRoute().GetCertificate().GetSpec().SecretName != "" {
+			secretName = ba.GetRoute().GetCertificate().GetSpec().SecretName
+		}
+		if ba.GetRoute().GetCertificateSecretRef() != nil {
+			secretName = *ba.GetRoute().GetCertificateSecretRef()
+		}
+		err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: mObj.GetNamespace()}, tlsSecret)
 		if err != nil {
 			r.ManageError(err, common.StatusConditionTypeReconciled, ba)
 			return "", "", "", "", err
@@ -668,6 +686,10 @@ func (r *ReconcilerBase) GetRouteTLSValues(ba common.BaseApplication) (key strin
 		v, ok = tlsSecret.Data["tls.key"]
 		if ok {
 			key = string(v)
+		}
+		v, ok = tlsSecret.Data["destCA.crt"]
+		if ok {
+			destCa = string(v)
 		}
 	}
 	return key, cert, ca, destCa, nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -232,13 +232,20 @@ func CustomizePodSpec(pts *corev1.PodTemplateSpec, ba common.BaseApplication) {
 	pts.Spec.Containers[0].VolumeMounts = ba.GetVolumeMounts()
 	pts.Spec.Volumes = ba.GetVolumes()
 
-	if ba.GetService().GetCertificate() != nil {
+	if ba.GetService().GetCertificate() != nil || ba.GetService().GetCertificateSecretRef() != nil {
+		secretName := obj.GetName() + "-svc-tls"
+		if ba.GetService().GetCertificate() != nil && ba.GetService().GetCertificate().GetSpec().SecretName != "" {
+			secretName = ba.GetService().GetCertificate().GetSpec().SecretName
+		}
+		if ba.GetService().GetCertificateSecretRef() != nil {
+			secretName = *ba.GetService().GetCertificateSecretRef()
+		}
 		pts.Spec.Containers[0].Env = append(pts.Spec.Containers[0].Env, corev1.EnvVar{Name: "TLS_DIR", Value: "/etc/x509/certs"})
 		pts.Spec.Volumes = append(pts.Spec.Volumes, corev1.Volume{
 			Name: "svc-certificate",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: obj.GetName() + "-svc-tls",
+					SecretName: secretName,
 				},
 			},
 		})


### PR DESCRIPTION
**What this PR does / why we need it?**:

-  Adds a field to RuntimeComponent CRD to allow service and routes to use manually provided certificates