### PR TITLE
Change monitoring label

### DIFF
--- a/pkg/controller/runtimecomponent/runtimecomponent_controller.go
+++ b/pkg/controller/runtimecomponent/runtimecomponent_controller.go
@@ -469,10 +469,10 @@ func (r *ReconcileRuntimeComponent) Reconcile(request reconcile.Request) (reconc
 		appstacksutils.CustomizeService(svc, ba)
 		svc.Annotations = appstacksutils.MergeMaps(svc.Annotations, instance.Spec.Service.Annotations)
 		if instance.Spec.Monitoring != nil {
-			svc.Labels["app."+ba.GetGroupName()+"/monitor"] = "true"
+			svc.Labels["monitor."+ba.GetGroupName()+"/enabled"] = "true"
 		} else {
-			if _, ok := svc.Labels["app."+ba.GetGroupName()+"/monitor"]; ok {
-				delete(svc.Labels, "app."+ba.GetGroupName()+"/monitor")
+			if _, ok := svc.Labels["monitor."+ba.GetGroupName()+"/enabled"]; ok {
+				delete(svc.Labels, "monitor."+ba.GetGroupName()+"/enabled")
 			}
 		}
 		return nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -556,8 +556,8 @@ func CustomizeServiceMonitor(sm *prometheusv1.ServiceMonitor, ba common.BaseAppl
 
 	sm.Spec.Selector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"app.kubernetes.io/instance":            obj.GetName(),
-			"app." + ba.GetGroupName() + "/monitor": "true",
+			"app.kubernetes.io/instance":                obj.GetName(),
+			"monitor." + ba.GetGroupName() + "/enabled": "true",
 		},
 	}
 	if len(sm.Spec.Endpoints) == 0 {


### PR DESCRIPTION
Signed-off-by: leochr <leojc@ca.ibm.com>

**What this PR does / why we need it?**:

- Change monitoring label from `app.app.stacks/monitor` to `monitor.app.stacks/enabled`
- Tested that the match label selector on ServiceMonitor can be changed after creation. So upgrade scenario shouldn't be affected.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes # https://github.com/appsody/appsody-operator/issues/170
