### PR TITLE
Fix autoscaling bug with number of replicas

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -27,7 +27,9 @@ func CustomizeDeployment(deploy *appsv1.Deployment, ba common.BaseComponent) {
 	deploy.Labels = ba.GetLabels()
 	deploy.Annotations = MergeMaps(deploy.Annotations, ba.GetAnnotations())
 
-	deploy.Spec.Replicas = ba.GetReplicas()
+	if ba.GetAutoscaling() == nil {
+		deploy.Spec.Replicas = ba.GetReplicas()
+	}
 
 	if deploy.Spec.Selector == nil {
 		deploy.Spec.Selector = &metav1.LabelSelector{
@@ -46,7 +48,9 @@ func CustomizeStatefulSet(statefulSet *appsv1.StatefulSet, ba common.BaseCompone
 	statefulSet.Labels = ba.GetLabels()
 	statefulSet.Annotations = MergeMaps(statefulSet.Annotations, ba.GetAnnotations())
 
-	statefulSet.Spec.Replicas = ba.GetReplicas()
+	if ba.GetAutoscaling() == nil {
+		statefulSet.Spec.Replicas = ba.GetReplicas()
+	}
 	statefulSet.Spec.ServiceName = obj.GetName() + "-headless"
 	if statefulSet.Spec.Selector == nil {
 		statefulSet.Spec.Selector = &metav1.LabelSelector{

--- a/test/e2e/runtime_autoscaling.go
+++ b/test/e2e/runtime_autoscaling.go
@@ -45,7 +45,7 @@ func RuntimeAutoScalingTest(t *testing.T) {
 	// create one replica of the operator deployment in current namespace with provided name
 	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "runtime-component-operator", 1, retryInterval, operatorTimeout)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	// Make basic runtime omponent with 1 replica
@@ -71,7 +71,7 @@ func RuntimeAutoScalingTest(t *testing.T) {
 		r.Spec.Autoscaling = setAutoScale(5, 50)
 	})
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	// Check the name field that matches
@@ -90,7 +90,7 @@ func RuntimeAutoScalingTest(t *testing.T) {
 
 	err = waitForHPA(hpa, t, 1, 5, 50, f, options)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	updateTest(t, f, runtimeComponent, options, namespace, hpa)
@@ -175,7 +175,7 @@ func updateTest(t *testing.T, f *framework.Framework, runtimeComponent *appstack
 		r.Spec.Autoscaling = setAutoScale(3, 2, 30)
 	})
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	timestamp := time.Now().UTC()
@@ -185,7 +185,7 @@ func updateTest(t *testing.T, f *framework.Framework, runtimeComponent *appstack
 
 	err = waitForHPA(hpa, t, 2, 3, 30, f, options)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 }
 
@@ -198,7 +198,7 @@ func minMaxTest(t *testing.T, f *framework.Framework, runtimeComponent *appstack
 		r.Spec.Autoscaling = setAutoScale(1, 6, 10)
 	})
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	timestamp := time.Now().UTC()
@@ -208,7 +208,12 @@ func minMaxTest(t *testing.T, f *framework.Framework, runtimeComponent *appstack
 
 	err = waitForHPA(hpa, t, 2, 3, 30, f, options)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-runtime-autoscaling", 2, retryInterval, timeout)
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
 	}
 }
 
@@ -221,7 +226,7 @@ func minBoundaryTest(t *testing.T, f *framework.Framework, runtimeComponent *app
 		r.Spec.Autoscaling = setAutoScale(4, 0, 20)
 	})
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	timestamp := time.Now().UTC()
@@ -231,7 +236,12 @@ func minBoundaryTest(t *testing.T, f *framework.Framework, runtimeComponent *app
 
 	err = waitForHPA(hpa, t, 2, 3, 30, f, options)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
+	}
+
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-runtime-autoscaling", 2, retryInterval, timeout)
+	if err != nil {
+		util.FailureCleanup(t, f, namespace, err)
 	}
 }
 
@@ -253,13 +263,13 @@ func incorrectFieldsTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 	// use TestCtx's create helper to create the object and add a cleanup function for the new object
 	err = f.Client.Create(goctx.TODO(), runtimeComponent, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	// wait for example-runtime-autoscaling to reach 1 replicas
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-runtime-autoscaling2", 1, retryInterval, timeout)
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	// Check the name field that matches
@@ -277,7 +287,7 @@ func incorrectFieldsTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 		r.Spec.Autoscaling = setAutoScale(4)
 	})
 	if err != nil {
-		t.Fatal(err)
+		util.FailureCleanup(t, f, namespace, err)
 	}
 
 	timestamp = time.Now().UTC()


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Adds a guard to the deployment/statefulset customization functions that checks for the existence of autoscaler in the spec before updating the # of replicas in the resource. This prevents the loop of operator contradicting the HPA.
- My changes assume that we do not want the operator to touch the # of replicas if there's an autoscaler enabled.
- Updated the autoscaler test to watch that the deployment actually gets to the minimum number of replicas before passing the test. Rather than just watching the HPA resource definition.
  - Note that I actually don't think this e2e CAN catch this specific failure, as it still technically reaches 2 replicas momentarily and then starts going up and down over and over. This would be better mandated by unit tests.

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #68 
