### PR TITLE
Use cert image

### DIFF
--- a/deploy/olm-catalog/runtime-component-operator-certified/runtime-component-operator.v0.4.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/runtime-component-operator-certified/runtime-component-operator.v0.4.1.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"app.stacks/v1beta1","kind":"RuntimeComponent","metadata":{"name":"example-runtime-component"},"spec":{"applicationImage":"registry.access.redhat.com/ubi8/nodejs-12:1-27"}}]'
+    alm-examples: '[{"apiVersion":"app.stacks/v1beta1","kind":"RuntimeComponent","metadata":{"name":"example-runtime-component"},"spec":{"applicationImage":"registry.connect.redhat.com/ibm/open-liberty-samples:springPetClinic"}}]'
     capabilities: Auto Pilot
     categories: Application Runtime
     certified: 'true'


### PR DESCRIPTION
The Red Hat certification needs a certified image during the default installation, so referencing a certified sample I uploaded.