### PR TITLE
Add default hostname suffix to ConfigMap

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -17,6 +17,9 @@ const (
 	// OpConfigSvcBindingGVKs a comma-seperated list of GroupVersionKind values in "<Kind>.<version>.<group>" format.
 	// e.g. "CronTab.v1.stable.example.com"
 	OpConfigSvcBindingGVKs = "serviceBinding.groupVersionKinds"
+
+	// OpConfigDefaultHostname a DNS name to be used for hostname generation.
+	OpConfigDefaultHostname = "defaultHostname"
 )
 
 // Config stores operator configuration
@@ -39,5 +42,7 @@ func DefaultOpConfig() OpConfig {
 	cfg[OpConfigPropDefaultIssuer] = "self-signed"
 	cfg[OpConfigPropUseClusterIssuer] = "true"
 	cfg[OpConfigSvcBindingGVKs] = "ServiceBindingRequest.v1alpha1.apps.openshift.io"
+	cfg[OpConfigDefaultHostname] = ""
+
 	return cfg
 }

--- a/pkg/utils/reconciler.go
+++ b/pkg/utils/reconciler.go
@@ -361,6 +361,9 @@ func (r *ReconcilerBase) ReconcileCertificate(ba common.BaseComponent) (reconcil
 				// use routes host if no DNS information provided on certificate
 				if crt.Spec.CommonName == "" {
 					crt.Spec.CommonName = ba.GetRoute().GetHost()
+					if crt.Spec.CommonName == "" && common.Config[common.OpConfigDefaultHostname] != "" {
+						crt.Spec.CommonName = obj.GetName() + "-" + obj.GetNamespace() + "." + common.Config[common.OpConfigDefaultHostname]
+					}
 				}
 				if len(crt.Spec.DNSNames) == 0 {
 					crt.Spec.DNSNames = append(crt.Spec.DNSNames, crt.Spec.CommonName)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -97,7 +97,12 @@ func CustomizeRoute(route *routev1.Route, ba common.BaseComponent, key string, c
 	if ba.GetRoute() != nil {
 		rt := ba.GetRoute()
 		route.Annotations = MergeMaps(route.Annotations, rt.GetAnnotations())
-		route.Spec.Host = rt.GetHost()
+
+		host := rt.GetHost()
+		if host == "" && common.Config[common.OpConfigDefaultHostname] != "" {
+			host = obj.GetName() + "-" + obj.GetNamespace() + "." + common.Config[common.OpConfigDefaultHostname]
+		}
+		route.Spec.Host = host
 		route.Spec.Path = rt.GetPath()
 		if ba.GetRoute().GetTermination() != nil {
 			if route.Spec.TLS == nil {
@@ -925,9 +930,13 @@ func CustomizeIngress(ing *networkingv1beta1.Ingress, ba common.BaseComponent) {
 	if ba.GetService().GetPortName() != "" {
 		servicePort = ba.GetService().GetPortName()
 	}
+	host := rt.GetHost()
+	if host == "" && common.Config[common.OpConfigDefaultHostname] != "" {
+		host = obj.GetName() + "-" + obj.GetNamespace() + "." + common.Config[common.OpConfigDefaultHostname]
+	}
 	ing.Spec.Rules = []networkingv1beta1.IngressRule{
 		{
-			Host: rt.GetHost(),
+			Host: host,
 			IngressRuleValue: networkingv1beta1.IngressRuleValue{
 				HTTP: &networkingv1beta1.HTTPIngressRuleValue{
 					Paths: []networkingv1beta1.HTTPIngressPath{
@@ -957,7 +966,7 @@ func CustomizeIngress(ing *networkingv1beta1.Ingress, ba common.BaseComponent) {
 	if tlsSecretName != "" {
 		ing.Spec.TLS = []networkingv1beta1.IngressTLS{
 			{
-				Hosts:      []string{rt.GetHost()},
+				Hosts:      []string{host},
 				SecretName: tlsSecretName,
 			},
 		}


### PR DESCRIPTION
**What this PR does / why we need it?**:

-  Allows to define a hostname in operator's config map "defaultHostname" to be able to generate
  hostname. such as {appname}-{namespace}.{defaultHostname} 

