### PR TITLE
Run basic tests in minikube parallel to OCP tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ jobs:
     - name: Verify operator image build
       script: make build-image
       if: branch != master OR fork = true OR type = pull_request
-    - name: E2E testing
+    - name: E2E testing on Minikube
+      script: make test-minikube
+    - name: E2E testing on OCP 3.11
       script: make test-e2e
       if: fork = false
     ## if master branch build and push images on all three archs

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ setup: ## Ensure Operator SDK is installed
 setup-manifest:
 	./scripts/installers/install-manifest-tool.sh
 
+setup-minikube:
+	./scripts/installers/install-minikube.sh
+
 tidy: ## Clean up Go modules by adding missing and removing unused modules
 	go mod tidy
 
@@ -36,9 +39,12 @@ unit-test: ## Run unit tests
 test-e2e: setup ## Run end-to-end tests
 	./scripts/e2e.sh
 
+test-minikube: setup setup-minikube
+	CLUSTER_ENV="minikube" operator-sdk test local github.com/application-stacks/runtime-component-operator/test/e2e --verbose --debug --up-local --namespace default
+
 test-e2e-locally: setup
 	kubectl apply -f scripts/servicemonitor.crd.yaml
-	operator-sdk test local github.com/application-stacks/runtime-component-operator/test/e2e --verbose --debug --up-local --namespace ${WATCH_NAMESPACE}
+	CLUSTER_ENV="local" operator-sdk test local github.com/application-stacks/runtime-component-operator/test/e2e --verbose --debug --up-local --namespace default
 
 generate: setup ## Invoke `k8s` and `openapi` generators
 	operator-sdk generate k8s

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -44,7 +44,7 @@ main() {
     fi
 
     echo "****** Starting e2e tests..."
-    operator-sdk test local github.com/application-stacks/runtime-component-operator/test/e2e --go-test-flags "-timeout 35m" --image $(oc registry info)/openshift/runtime-operator:$TRAVIS_BUILD_NUMBER --verbose
+    CLUSTER_ENV="ocp" operator-sdk test local github.com/application-stacks/runtime-component-operator/test/e2e --go-test-flags "-timeout 35m" --image $(oc registry info)/openshift/runtime-operator:$TRAVIS_BUILD_NUMBER --verbose
     result=$?
     echo "****** Cleaning up tests..."
     cleanup

--- a/scripts/installers/install-minikube.sh
+++ b/scripts/installers/install-minikube.sh
@@ -5,7 +5,6 @@ set -e
 ## Some minikube job specific ENV variables
 export CHANGE_MINIKUBE_NONE_USER=true
 export MINIKUBE_WANTUPDATENOTIFICATION=false
-export MINIKUBE_WANTREPORTERRORPROMPT=false
 export MINIKUBE_HOME=$HOME
 export CHANGE_MINIKUBE_NONE_USER=true
 export KUBECONFIG=$HOME/.kube/config

--- a/scripts/installers/install-minikube.sh
+++ b/scripts/installers/install-minikube.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+## Some minikube job specific ENV variables
+export CHANGE_MINIKUBE_NONE_USER=true
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME=$HOME
+export CHANGE_MINIKUBE_NONE_USER=true
+export KUBECONFIG=$HOME/.kube/config
+
+function main () {
+  echo "****** Installing minikube..."
+  install_minikube
+
+  echo "****** Verifying installation..."
+  kubectl cluster-info
+  wait_for_kube
+  ## Run tests below
+  echo "Minikube enabled job is running..."
+
+}
+
+function install_minikube() {
+  sudo apt-get update -y
+  sudo apt-get -qq -y install conntrack
+  ## get kubectl
+  curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.1/bin/linux/amd64/kubectl \
+      && chmod +x kubectl \
+      && sudo mv kubectl /usr/local/bin/
+  ## Download minikube
+  curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.8.1/minikube-linux-amd64 \
+      && chmod +x minikube \
+      && sudo mv minikube /usr/local/bin/
+
+  mkdir -p $HOME/.kube $HOME/.minikube
+  touch $KUBECONFIG
+  sudo minikube start --profile=minikube --vm-driver=none --kubernetes-version=v1.18.1
+  minikube update-context --profile=minikube
+
+  eval "$(minikube docker-env --profile=minikube)" && export DOCKER_CLI='docker'
+}
+
+function wait_for_kube() {
+  local json_path='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+
+  until kubectl -n kube-system get pods -l k8s-app=kube-dns -o jsonpath="$json_path" 2>&1 | grep -q "Ready=True"; do
+    sleep 5;echo "waiting for kube-dns to be available"
+    kubectl get pods --all-namespaces
+  done
+}
+
+main "$@"

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
+
 	f.MainEntry(m)
 }

--- a/test/e2e/runtime_test.go
+++ b/test/e2e/runtime_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"os"
 	"testing"
 
 	"github.com/application-stacks/runtime-component-operator/pkg/apis"
@@ -16,19 +17,53 @@ func TestRuntimeComponent(t *testing.T) {
 			Kind: "RuntimeComponent",
 		},
 	}
+
+	cluster := os.Getenv("CLUSTER_ENV")
+	t.Logf("running e2e tests as '%s'", cluster)
+
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, runtimeComponentList)
 	if err != nil {
 		t.Fatalf("Failed to add CR scheme to framework: %v", err)
 	}
 
+	// Basic tests that are runnable locally in minishift/kube
 	t.Run("RuntimePullPolicyTest", RuntimePullPolicyTest)
 	t.Run("RuntimeBasicTest", RuntimeBasicTest)
-	t.Run("RuntimeStorageTest", RuntimeBasicStorageTest)
-	t.Run("RuntimePersistenceTest", RuntimePersistenceTest)
 	t.Run("RuntimeProbeTest", RuntimeProbeTest)
 	t.Run("RuntimeAutoScalingTest", RuntimeAutoScalingTest)
+	t.Run("RuntimeStorageTest", RuntimeBasicStorageTest)
+	t.Run("RuntimePersistenceTest", RuntimePersistenceTest)
+
+	if cluster != "local" {
+		// only test non-OCP features on minikube
+		if cluster == "minikube" {
+			testIndependantFeatures(t)
+			return
+		}
+
+		// test all features that require some configuration
+		testAdvancedFeatures(t)
+		// test featurest hat require OCP
+		if cluster == "ocp" {
+			testOCPFeatures(t)
+		}
+	}
+}
+
+func testAdvancedFeatures(t *testing.T) {
+	// These features require a bit of configuration
+	// which makes them less ideal for quick minikube tests
 	t.Run("RuntimeServiceMonitorTest", RuntimeServiceMonitorTest)
 	t.Run("RuntimeKnativeTest", RuntimeKnativeTest)
 	t.Run("RuntimeCertManagerTest", RuntimeCertManagerTest)
+}
+
+// Verify functionality that is tied to OCP
+func testOCPFeatures(t *testing.T) {
 	t.Run("RuntimeImageStreamTest", RuntimeImageStreamTest)
+}
+
+// Verify functionality that is not expected to run on OCP
+func testIndependantFeatures(t *testing.T) {
+	// TODO: implement test for ingress
 }


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Kicks of another job that sets up minikube on travis and runs all of the basic tests that do not rely on any pre-configuration (i.e. cert-manager or knative)
- Will also kick off any non-OCP functionality as well, this will be the ingress test once it's created but I think that's a separate PR.

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #96 
