### PR TITLE
Fix broken link

### DIFF
--- a/doc/readme.adoc
+++ b/doc/readme.adoc
@@ -1,4 +1,4 @@
 = Documentation
 
 * See the link:++user-guide.adoc++[user guide], for information on how to use the Runtime Component Operator.
-* See the link:++troubleshooting.adoc[troubleshooting guide] for information on how to investigate and resolve deployment problems.
+* See the link:++troubleshooting.adoc++[troubleshooting guide] for information on how to investigate and resolve deployment problems.


### PR DESCRIPTION
**What this PR does / why we need it?**:
Fixed the broken link in /doc/readme.adoc file. There were two plus signs missing, which caused the broken link.

**Which issue(s) this PR fixes**:
Fixes #109 
