### PR TITLE
Adding support for embedding Service Binding definition in RuntimeComponent CR

### DIFF
--- a/deploy/crds/app.stacks_runtimecomponents_crd.yaml
+++ b/deploy/crds/app.stacks_runtimecomponents_crd.yaml
@@ -94,6 +94,8 @@ spec:
               properties:
                 autoDetect:
                   type: boolean
+                embedded:
+                  type: object
                 resourceRef:
                   type: string
               type: object
@@ -476,8 +478,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -499,8 +501,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -570,8 +572,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -593,8 +595,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -662,8 +664,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -702,8 +704,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -822,8 +824,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -862,8 +864,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1092,8 +1094,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1132,8 +1134,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1312,8 +1314,8 @@ spec:
                       type: string
                     port:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: Name or number of the port to access on the container.
                         Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                     scheme:
@@ -1350,8 +1352,8 @@ spec:
                       type: string
                     port:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: Number or name of the port to access on the container.
                         Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                   required:
@@ -1568,8 +1570,8 @@ spec:
                         type: string
                       targetPort:
                         anyOf:
-                        - type: string
                         - type: integer
+                        - type: string
                         description: Name or number of the target port of the endpoint.
                           Mutually exclusive with port.
                       tlsConfig:
@@ -1775,8 +1777,8 @@ spec:
                       type: string
                     port:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: Name or number of the port to access on the container.
                         Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                     scheme:
@@ -1813,8 +1815,8 @@ spec:
                       type: string
                     port:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: Number or name of the port to access on the container.
                         Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                   required:
@@ -2205,8 +2207,8 @@ spec:
                         type: string
                       targetPort:
                         anyOf:
-                        - type: string
                         - type: integer
+                        - type: string
                         description: 'Number or name of the port to access on the
                           pods targeted by the service. Number must be in the range
                           1 to 65535. Name must be an IANA_SVC_NAME. If this is a
@@ -2530,8 +2532,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2553,8 +2555,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2624,8 +2626,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2647,8 +2649,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2716,8 +2718,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -2756,8 +2758,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -2876,8 +2878,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -2916,8 +2918,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -3146,8 +3148,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -3186,8 +3188,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.

--- a/deploy/releases/daily/runtime-component-crd.yaml
+++ b/deploy/releases/daily/runtime-component-crd.yaml
@@ -94,6 +94,8 @@ spec:
               properties:
                 autoDetect:
                   type: boolean
+                embedded:
+                  type: object
                 resourceRef:
                   type: string
               type: object
@@ -476,8 +478,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -499,8 +501,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -570,8 +572,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -593,8 +595,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -662,8 +664,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -702,8 +704,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -822,8 +824,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -862,8 +864,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1092,8 +1094,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1132,8 +1134,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -1312,8 +1314,8 @@ spec:
                       type: string
                     port:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: Name or number of the port to access on the container.
                         Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                     scheme:
@@ -1350,8 +1352,8 @@ spec:
                       type: string
                     port:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: Number or name of the port to access on the container.
                         Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                   required:
@@ -1568,8 +1570,8 @@ spec:
                         type: string
                       targetPort:
                         anyOf:
-                        - type: string
                         - type: integer
+                        - type: string
                         description: Name or number of the target port of the endpoint.
                           Mutually exclusive with port.
                       tlsConfig:
@@ -1775,8 +1777,8 @@ spec:
                       type: string
                     port:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: Name or number of the port to access on the container.
                         Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                     scheme:
@@ -1813,8 +1815,8 @@ spec:
                       type: string
                     port:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: Number or name of the port to access on the container.
                         Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                   required:
@@ -2205,8 +2207,8 @@ spec:
                         type: string
                       targetPort:
                         anyOf:
-                        - type: string
                         - type: integer
+                        - type: string
                         description: 'Number or name of the port to access on the
                           pods targeted by the service. Number must be in the range
                           1 to 65535. Name must be an IANA_SVC_NAME. If this is a
@@ -2530,8 +2532,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2553,8 +2555,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2624,8 +2626,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2647,8 +2649,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2716,8 +2718,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -2756,8 +2758,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -2876,8 +2878,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -2916,8 +2918,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -3146,8 +3148,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Name or number of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.
@@ -3186,8 +3188,8 @@ spec:
                             type: string
                           port:
                             anyOf:
-                            - type: string
                             - type: integer
+                            - type: string
                             description: Number or name of the port to access on the
                               container. Number must be in the range 1 to 65535. Name
                               must be an IANA_SVC_NAME.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.17.2
-	k8s.io/apiextensions-apiserver v0.17.1
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a

--- a/pkg/apis/appstacks/v1beta1/runtimecomponent_types.go
+++ b/pkg/apis/appstacks/v1beta1/runtimecomponent_types.go
@@ -8,6 +8,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -148,8 +149,9 @@ type ServiceBindingAuth struct {
 
 // RuntimeComponentBindings represents service binding related parameters
 type RuntimeComponentBindings struct {
-	AutoDetect  *bool  `json:"autoDetect,omitempty"`
-	ResourceRef string `json:"resourceRef,omitempty"`
+	AutoDetect  *bool                 `json:"autoDetect,omitempty"`
+	ResourceRef string                `json:"resourceRef,omitempty"`
+	Embedded    *runtime.RawExtension `json:"embedded,omitempty"`
 }
 
 // RuntimeComponentStatus defines the observed state of RuntimeComponent
@@ -621,6 +623,11 @@ func (r *RuntimeComponentBindings) GetAutoDetect() *bool {
 // GetResourceRef returns name of ServiceBinding CRs created manually in the same namespace as the RuntimeComponent CR
 func (r *RuntimeComponentBindings) GetResourceRef() string {
 	return r.ResourceRef
+}
+
+// GetEmbedded returns the embedded underlying Service Binding resource
+func (r *RuntimeComponentBindings) GetEmbedded() *runtime.RawExtension {
+	return r.Embedded
 }
 
 // Initialize the RuntimeComponent instance

--- a/pkg/apis/appstacks/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/appstacks/v1beta1/zz_generated.deepcopy.go
@@ -128,6 +128,11 @@ func (in *RuntimeComponentBindings) DeepCopyInto(out *RuntimeComponentBindings) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Embedded != nil {
+		in, out := &in.Embedded, &out.Embedded
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -6,6 +6,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // StatusConditionType ...
@@ -129,6 +130,7 @@ type ServiceBindingAuth interface {
 type BaseComponentBindings interface {
 	GetAutoDetect() *bool
 	GetResourceRef() string
+	GetEmbedded() *runtime.RawExtension
 }
 
 // ServiceBindingCategory ...

--- a/pkg/controller/runtimecomponent/enqueue_with_matcher.go
+++ b/pkg/controller/runtimecomponent/enqueue_with_matcher.go
@@ -95,6 +95,7 @@ func (i *ImageStreamMatcher) Match(imageStreamTag metav1.Object) ([]appstacksv1b
 		}
 		apps = append(apps, appList.Items...)
 	}
+
 	return apps, nil
 }
 
@@ -122,11 +123,10 @@ func (b *BindingSecretMatcher) Match(secret metav1.Object) ([]appstacksv1beta1.R
 	// If we are able to find an app with the secret name, add the app. This is to cover the autoDetect scenario
 	app := &appstacksv1beta1.RuntimeComponent{}
 	err = b.klient.Get(context.Background(), types.NamespacedName{Name: secret.GetName(), Namespace: secret.GetNamespace()}, app)
-	if err != nil {
-		if !kerrors.IsNotFound(err) {
-			return nil, err
-		}
+	if err == nil {
+		apps = append(apps, *app)
+	} else if !kerrors.IsNotFound(err) {
+		return nil, err
 	}
-	apps = append(apps, *app)
 	return apps, nil
 }

--- a/pkg/controller/runtimecomponent/enqueue_with_matcher.go
+++ b/pkg/controller/runtimecomponent/enqueue_with_matcher.go
@@ -28,7 +28,7 @@ const (
 // the modified resource
 type EnqueueRequestsForCustomIndexField struct {
 	handler.Funcs
-	Matcher func(metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error)
+	Matcher CustomMatcher
 }
 
 // Update implements EventHandler
@@ -48,7 +48,7 @@ func (e *EnqueueRequestsForCustomIndexField) Generic(evt event.GenericEvent, q w
 
 // handle common implementation to enqueue reconcile Requests for applications
 func (e *EnqueueRequestsForCustomIndexField) handle(evtMeta metav1.Object, evtObj runtime.Object, q workqueue.RateLimitingInterface) {
-	apps, _ := e.Matcher(evtMeta)
+	apps, _ := e.Matcher.Match(evtMeta)
 	for _, app := range apps {
 		q.Add(reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -58,64 +58,75 @@ func (e *EnqueueRequestsForCustomIndexField) handle(evtMeta metav1.Object, evtOb
 	}
 }
 
-// CreateImageStreamMatcher return a func that matches all applications using the input ImageStreamTag
-func CreateImageStreamMatcher(clnt client.Client, watchNamespaces []string) func(metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error) {
-	matcher := func(imageStreamTag metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error) {
-		apps := []appstacksv1beta1.RuntimeComponent{}
-		var namespaces []string
-		if appstacksutils.IsClusterWide(watchNamespaces) {
-			nsList := &corev1.NamespaceList{}
-			if err := clnt.List(context.Background(), nsList, client.InNamespace("")); err != nil {
-				return nil, err
-			}
-			for _, ns := range nsList.Items {
-				namespaces = append(namespaces, ns.Name)
-			}
-		} else {
-			namespaces = watchNamespaces
-		}
-		for _, ns := range namespaces {
-			appList := &appstacksv1beta1.RuntimeComponentList{}
-			err := clnt.List(context.Background(),
-				appList,
-				client.InNamespace(ns),
-				client.MatchingFields{indexFieldImageStreamName: imageStreamTag.GetNamespace() + "/" + imageStreamTag.GetName()})
-			if err != nil {
-				return nil, err
-			}
-			apps = append(apps, appList.Items...)
-		}
-		return apps, nil
-	}
-	return matcher
+// CustomMatcher is an interface for matching apps that satisfy a custom logic
+type CustomMatcher interface {
+	Match(metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error)
 }
 
-//CreateBindingSecretMatcher return a func that matches all applications that "could" rely on the secret as a secret binding
-func CreateBindingSecretMatcher(clnt client.Client) func(metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error) {
-	matcher := func(secret metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error) {
-		apps := []appstacksv1beta1.RuntimeComponent{}
+// ImageStreamMatcher implements CustomMatcher for Image Streams
+type ImageStreamMatcher struct {
+	klient          client.Client
+	watchNamespaces []string
+}
 
-		// Adding apps which have this secret defined in the spec.bindings.resourceRef
+// Match returns all applications using the input ImageStreamTag
+func (i *ImageStreamMatcher) Match(imageStreamTag metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error) {
+	apps := []appstacksv1beta1.RuntimeComponent{}
+	var namespaces []string
+	if appstacksutils.IsClusterWide(i.watchNamespaces) {
+		nsList := &corev1.NamespaceList{}
+		if err := i.klient.List(context.Background(), nsList, client.InNamespace("")); err != nil {
+			return nil, err
+		}
+		for _, ns := range nsList.Items {
+			namespaces = append(namespaces, ns.Name)
+		}
+	} else {
+		namespaces = watchNamespaces
+	}
+	for _, ns := range namespaces {
 		appList := &appstacksv1beta1.RuntimeComponentList{}
-		err := clnt.List(context.Background(),
+		err := i.klient.List(context.Background(),
 			appList,
-			client.InNamespace(secret.GetNamespace()),
-			client.MatchingFields{indexFieldBindingsResourceRef: secret.GetName()})
+			client.InNamespace(ns),
+			client.MatchingFields{indexFieldImageStreamName: imageStreamTag.GetNamespace() + "/" + imageStreamTag.GetName()})
 		if err != nil {
 			return nil, err
 		}
 		apps = append(apps, appList.Items...)
-
-		// If we are able to find an app with the secret name, add the app. This is to cover the autoDetect scenario
-		app := &appstacksv1beta1.RuntimeComponent{}
-		err = clnt.Get(context.Background(), types.NamespacedName{Name: secret.GetName(), Namespace: secret.GetNamespace()}, app)
-		if err != nil {
-			if !kerrors.IsNotFound(err) {
-				return nil, err
-			}
-		}
-		apps = append(apps, *app)
-		return apps, nil
 	}
-	return matcher
+	return apps, nil
+}
+
+// BindingSecretMatcher implements CustomMatcher for Binding Secrets
+type BindingSecretMatcher struct {
+	klient client.Client
+}
+
+// Match returns all applications that "could" rely on the secret as a secret binding by finding apps that have
+// resourceRef matching the secret name OR app name matching the secret name
+func (b *BindingSecretMatcher) Match(secret metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error) {
+	apps := []appstacksv1beta1.RuntimeComponent{}
+
+	// Adding apps which have this secret defined in the spec.bindings.resourceRef
+	appList := &appstacksv1beta1.RuntimeComponentList{}
+	err := b.klient.List(context.Background(),
+		appList,
+		client.InNamespace(secret.GetNamespace()),
+		client.MatchingFields{indexFieldBindingsResourceRef: secret.GetName()})
+	if err != nil {
+		return nil, err
+	}
+	apps = append(apps, appList.Items...)
+
+	// If we are able to find an app with the secret name, add the app. This is to cover the autoDetect scenario
+	app := &appstacksv1beta1.RuntimeComponent{}
+	err = b.klient.Get(context.Background(), types.NamespacedName{Name: secret.GetName(), Namespace: secret.GetNamespace()}, app)
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			return nil, err
+		}
+	}
+	apps = append(apps, *app)
+	return apps, nil
 }

--- a/pkg/controller/runtimecomponent/enqueue_with_matcher.go
+++ b/pkg/controller/runtimecomponent/enqueue_with_matcher.go
@@ -30,7 +30,7 @@ const (
 // the modified resource
 type EnqueueRequestsForCustomIndexField struct {
 	handler.Funcs
-	Matcher CustomMatcher
+	Matcher  CustomMatcher
 }
 
 // Update implements EventHandler
@@ -67,28 +67,28 @@ type CustomMatcher interface {
 
 // ImageStreamMatcher implements CustomMatcher for Image Streams
 type ImageStreamMatcher struct {
-	klient          client.Client
-	watchNamespaces []string
+	Klient          client.Client
+	WatchNamespaces []string
 }
 
 // Match returns all applications using the input ImageStreamTag
 func (i *ImageStreamMatcher) Match(imageStreamTag metav1.Object) ([]appstacksv1beta1.RuntimeComponent, error) {
 	apps := []appstacksv1beta1.RuntimeComponent{}
 	var namespaces []string
-	if appstacksutils.IsClusterWide(i.watchNamespaces) {
+	if appstacksutils.IsClusterWide(i.WatchNamespaces) {
 		nsList := &corev1.NamespaceList{}
-		if err := i.klient.List(context.Background(), nsList, client.InNamespace("")); err != nil {
+		if err := i.Klient.List(context.Background(), nsList, client.InNamespace("")); err != nil {
 			return nil, err
 		}
 		for _, ns := range nsList.Items {
 			namespaces = append(namespaces, ns.Name)
 		}
 	} else {
-		namespaces = watchNamespaces
+		namespaces = i.WatchNamespaces
 	}
 	for _, ns := range namespaces {
 		appList := &appstacksv1beta1.RuntimeComponentList{}
-		err := i.klient.List(context.Background(),
+		err := i.Klient.List(context.Background(),
 			appList,
 			client.InNamespace(ns),
 			client.MatchingFields{indexFieldImageStreamName: imageStreamTag.GetNamespace() + "/" + imageStreamTag.GetName()})

--- a/pkg/controller/runtimecomponent/runtimecomponent_controller.go
+++ b/pkg/controller/runtimecomponent/runtimecomponent_controller.go
@@ -449,7 +449,7 @@ func (r *ReconcileRuntimeComponent) Reconcile(request reconcile.Request) (reconc
 		return result, nil
 	}
 
-	if r.IsSeriveBindingSupported() {
+	if r.IsServiceBindingSupported() {
 		result, err = r.ReconcileBindings(instance)
 		if err != nil || result != (reconcile.Result{}) {
 			return result, err

--- a/pkg/controller/runtimecomponent/runtimecomponent_controller.go
+++ b/pkg/controller/runtimecomponent/runtimecomponent_controller.go
@@ -119,6 +119,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	reconciler.SetController(c)
+
 	watchNamespaces, err := appstacksutils.GetWatchNamespaces()
 	if err != nil {
 		log.Error(err, "Failed to get watch namespace")

--- a/pkg/controller/runtimecomponent/runtimecomponent_controller.go
+++ b/pkg/controller/runtimecomponent/runtimecomponent_controller.go
@@ -242,7 +242,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	err = c.Watch(
 		&source.Kind{Type: &corev1.Secret{}},
 		&EnqueueRequestsForCustomIndexField{
-			Matcher: CreateBindingSecretMatcher(mgr.GetClient()),
+			Matcher: &BindingSecretMatcher{
+				klient: mgr.GetClient(),
+			},
 		})
 	if err != nil {
 		return err
@@ -253,7 +255,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		c.Watch(
 			&source.Kind{Type: &imagev1.ImageStream{}},
 			&EnqueueRequestsForCustomIndexField{
-				Matcher: CreateImageStreamMatcher(mgr.GetClient(), watchNamespaces),
+				Matcher: &ImageStreamMatcher{
+					klient:          mgr.GetClient(),
+					watchNamespaces: watchNamespaces,
+				},
 			})
 	}
 

--- a/pkg/controller/runtimecomponent/runtimecomponent_controller.go
+++ b/pkg/controller/runtimecomponent/runtimecomponent_controller.go
@@ -256,8 +256,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			&source.Kind{Type: &imagev1.ImageStream{}},
 			&EnqueueRequestsForCustomIndexField{
 				Matcher: &ImageStreamMatcher{
-					klient:          mgr.GetClient(),
-					watchNamespaces: watchNamespaces,
+					Klient:          mgr.GetClient(),
+					WatchNamespaces: watchNamespaces,
 				},
 			})
 	}

--- a/pkg/utils/reconciler.go
+++ b/pkg/utils/reconciler.go
@@ -26,6 +26,7 @@ import (
 	applicationsv1beta1 "sigs.k8s.io/application/pkg/apis/app/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -38,6 +39,7 @@ type ReconcilerBase struct {
 	recorder   record.EventRecorder
 	restConfig *rest.Config
 	discovery  discovery.DiscoveryInterface
+	controller controller.Controller
 }
 
 //NewReconcilerBase creates a new ReconcilerBase
@@ -48,6 +50,16 @@ func NewReconcilerBase(client client.Client, scheme *runtime.Scheme, restConfig 
 		recorder:   recorder,
 		restConfig: restConfig,
 	}
+}
+
+// GetController returns controller
+func (r *ReconcilerBase) GetController() controller.Controller {
+	return r.controller
+}
+
+// SetController sets controller
+func (r *ReconcilerBase) SetController(c controller.Controller) {
+	r.controller = c
 }
 
 // GetClient returns client

--- a/pkg/utils/reconciler.go
+++ b/pkg/utils/reconciler.go
@@ -110,7 +110,7 @@ func (r *ReconcilerBase) CreateOrUpdate(obj metav1.Object, owner metav1.Object, 
 	var gvk schema.GroupVersionKind
 	gvk, err = apiutil.GVKForObject(runtimeObj, r.scheme)
 	if err == nil {
-		log.Info("Reconciled", "Kind", gvk.Kind, "Name", obj.GetName(), "Status", result)
+		log.Info("Reconciled", "Kind", gvk.Kind, "Namespace", obj.GetNamespace(), "Name", obj.GetName(), "Status", result)
 	}
 
 	return err

--- a/pkg/utils/service_binding_reconciler.go
+++ b/pkg/utils/service_binding_reconciler.go
@@ -501,6 +501,7 @@ func (r *ReconcilerBase) updateBindingStatus(bindings []string, ba common.BaseCo
 
 func (r *ReconcilerBase) createOrUpdateEmbedded(embedded *unstructured.Unstructured, ba common.BaseComponent) error {
 	mObj := ba.(metav1.Object)
+	result := controllerutil.OperationResultNone
 	existing := &unstructured.Unstructured{}
 	existing.SetAPIVersion(embedded.GetAPIVersion())
 	existing.SetKind(embedded.GetKind())
@@ -512,7 +513,7 @@ func (r *ReconcilerBase) createOrUpdateEmbedded(embedded *unstructured.Unstructu
 			if err != nil {
 				return err
 			}
-
+			result = controllerutil.OperationResultCreated
 			// add watcher
 			err = r.controller.Watch(&source.Kind{Type: existing}, &handler.EnqueueRequestForOwner{
 				IsController: true,
@@ -532,9 +533,11 @@ func (r *ReconcilerBase) createOrUpdateEmbedded(embedded *unstructured.Unstructu
 			if err != nil {
 				return err
 			}
+			result = controllerutil.OperationResultUpdated
 		}
 	}
 
+	log.Info("Reconciled", "Kind", embedded.GetKind(), "Namespace", mObj.GetNamespace(), "Name", mObj.GetName(), "Status", result)
 	return nil
 }
 

--- a/pkg/utils/service_binding_reconciler.go
+++ b/pkg/utils/service_binding_reconciler.go
@@ -308,8 +308,10 @@ func (r *ReconcilerBase) reconcileExternals(ba common.BaseComponent) (retRes rec
 			bindingObj := &unstructured.Unstructured{}
 			bindingObj.SetGroupVersionKind(gvk)
 			err := r.client.Get(context.Background(), key, bindingObj)
-			if client.IgnoreNotFound(err) != nil {
-				log.Error(errors.Wrapf(err, "failed to find a service binding resource during auto-detect for GVK %q", gvk), "failed to get Service Binding CR")
+			if err != nil {
+				if !kerrors.IsNotFound(err) {
+					log.Error(errors.Wrapf(err, "failed to find a service binding resource during auto-detect for GVK %q", gvk), "failed to get Service Binding CR")
+				}
 				continue
 			}
 
@@ -590,5 +592,5 @@ func (r *ReconcilerBase) updateEmbeddedObject(object map[string]interface{}, emb
 }
 
 func getDefaultServiceBindingName(ba common.BaseComponent) string {
-	return (ba.(metav1.Object)).GetName() + "-bindings"
+	return (ba.(metav1.Object)).GetName() + "-binding"
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-
 // CustomizeDeployment ...
 func CustomizeDeployment(deploy *appsv1.Deployment, ba common.BaseComponent) {
 	obj := ba.(metav1.Object)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+
 // CustomizeDeployment ...
 func CustomizeDeployment(deploy *appsv1.Deployment, ba common.BaseComponent) {
 	obj := ba.(metav1.Object)


### PR DESCRIPTION
**What this PR does / why we need it?**:
- Added `bindings.embedded` to `RuntimeComponent` type as a free-form YAML. This allows creating SBR while not relying on the SBR CRD since there are going to be changes in GVK and well as `spec` fields.

**Does this PR introduce a user-facing change?** To be delivered in a separate PR
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**: #100 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
