### PR TITLE
Quick fix to TLS Secret example.

### DIFF
--- a/doc/user-guide.adoc
+++ b/doc/user-guide.adoc
@@ -899,7 +899,7 @@ data:
     Route public certificate...(base64)
   tls.key: >-
     Route private key...(base64)
-  destCA: >-
+  destCA.crt: >-
     Pod/Service certificate Certificate Authority (base64). Might be required when using reencrypt termination policy.
 type: kubernetes.io/tls
 ----


### PR DESCRIPTION
**What this PR does / why we need it?**:
Added missing `.crt` after destCA. Encountered this typo while developing the E2E test.
