### PR TITLE
Updated Image Stream lookup logic to query for Image Stream Tags

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -56,7 +56,8 @@ rules:
 - apiGroups:
   - image.openshift.io
   resources:
-  - '*'
+  - imagestreams
+  - imagestreamtags
   verbs:
   - '*'
 - apiGroups:

--- a/deploy/releases/daily/runtime-component-cluster-rbac.yaml
+++ b/deploy/releases/daily/runtime-component-cluster-rbac.yaml
@@ -57,7 +57,8 @@ rules:
 - apiGroups:
   - image.openshift.io
   resources:
-  - '*'
+  - imagestreams
+  - imagestreamtags
   verbs:
   - '*'
 - apiGroups:

--- a/deploy/releases/daily/runtime-component-operator.yaml
+++ b/deploy/releases/daily/runtime-component-operator.yaml
@@ -60,7 +60,8 @@ rules:
 - apiGroups:
   - image.openshift.io
   resources:
-  - '*'
+  - imagestreams
+  - imagestreamtags
   verbs:
   - '*'
 - apiGroups:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -55,7 +55,8 @@ rules:
 - apiGroups:
   - image.openshift.io
   resources:
-  - '*'
+  - imagestreams
+  - imagestreamtags
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/controller/runtimecomponent/runtimecomponent_controller_test.go
+++ b/pkg/controller/runtimecomponent/runtimecomponent_controller_test.go
@@ -78,9 +78,10 @@ func TestRuntimeController(t *testing.T) {
 
 	// Create a fake client to mock API calls.
 	cl := fakeclient.NewFakeClient(objs...)
+	rcl := fakeclient.NewFakeClient(objs...)
 
 	// Create a ReconcileRuntimeComponent object
-	rb := appstacksutils.NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+	rb := appstacksutils.NewReconcilerBase(rcl, cl, s, &rest.Config{}, record.NewFakeRecorder(10))
 	r := &ReconcileRuntimeComponent{ReconcilerBase: rb}
 	r.SetDiscoveryClient(createFakeDiscoveryClient())
 

--- a/pkg/utils/reconciler.go
+++ b/pkg/utils/reconciler.go
@@ -34,6 +34,7 @@ import (
 
 // ReconcilerBase base reconciler with some common behaviour
 type ReconcilerBase struct {
+	apiReader  client.Reader
 	client     client.Client
 	scheme     *runtime.Scheme
 	recorder   record.EventRecorder
@@ -43,8 +44,9 @@ type ReconcilerBase struct {
 }
 
 //NewReconcilerBase creates a new ReconcilerBase
-func NewReconcilerBase(client client.Client, scheme *runtime.Scheme, restConfig *rest.Config, recorder record.EventRecorder) ReconcilerBase {
+func NewReconcilerBase(apiReader client.Reader, client client.Client, scheme *runtime.Scheme, restConfig *rest.Config, recorder record.EventRecorder) ReconcilerBase {
 	return ReconcilerBase{
+		apiReader:  apiReader,
 		client:     client,
 		scheme:     scheme,
 		recorder:   recorder,
@@ -65,6 +67,18 @@ func (r *ReconcilerBase) SetController(c controller.Controller) {
 // GetClient returns client
 func (r *ReconcilerBase) GetClient() client.Client {
 	return r.client
+}
+
+// GetAPIReader returns a client.Reader. Use client.Reader only if a
+// particular resource does not implement the 'watch' verb such as
+// ImageStreamTag. This is because the operator-sdk Client
+// automatically performs a Watch on all the objects that are obtained
+// with Get, but some resources such as the ImageStreamTag kind does not
+// implement the Watch verb, which caused errors.
+// Here is an example of how the error would look like:
+//  `Failed to watch *v1.ImageStreamTag: the server does not allow this method on the requested resource (get imagestreamtags.image.openshift.io)`
+func (r *ReconcilerBase) GetAPIReader() client.Reader {
+	return r.apiReader
 }
 
 // GetRecorder returns the underlying recorder


### PR DESCRIPTION
**What this PR does / why we need it?**:
- Updated image stream lookup logic to query for a specific `ImageStreamTag` based on the value of the `.spec.applicationImage` parameter
- Since `ImageStreamTag` doesn't implement `Watch` verb, Operator SDK's client cannot be used to do `GET` on the resource. The workaround is to use [`client.Reader`](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client#Reader) based on the [Operator SDK FAQ](https://master.sdk.operatorframework.io/docs/faqs/faqs/):
  > In rare cases, it also could be that the particular resource does not implement the `watch` verb. In this case, it is necessary to use the [client.Reader][client.Reader] instead of the default split client. The manager's `GetAPIReader()` function can be used to get this reader.

  Therefore, this PR updates `ReconcilerBase` struct to have a `client.Reader` field.


**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**: https://github.com/application-stacks/runtime-component-operator/issues/155
