### PR TITLE
Updates to build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ jobs:
     - name: E2E testing on OCP 4.3
       script: make test-e2e
       if: fork = false
-    - name: E2E testing on OCP 3.11
-      script: make test-e2e-legacy
-      if: fork = false
     ## if master branch build and push images on all three archs
     - name: Build image on amd64
       stage: build

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,6 @@ unit-test: ## Run unit tests
 test-e2e: setup
 	./scripts/e2e.sh --cluster-url ${CLUSTER_43_URL} --cluster-token ${CLUSTER_43_TOKEN} --registry-name image-registry --registry-namespace openshift-image-registry
 
-test-e2e-legacy: setup ## Run end-to-end tests
-	./scripts/e2e.sh --cluster-url ${CLUSTER_311_URL} --cluster-token ${CLUSTER_311_TOKEN} --registry-name docker-registry --registry-namespace default
-
 test-minikube: setup setup-minikube
 	CLUSTER_ENV="minikube" operator-sdk test local github.com/application-stacks/runtime-component-operator/test/e2e --verbose --debug --up-local --namespace ${WATCH_NAMESPACE}
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -5,10 +5,8 @@ readonly SERVICE_ACCOUNT="travis-tests"
 # login_cluster : Download oc cli and use it to log into our persistent cluster
 login_cluster(){
     # Install kubectl and oc
-    curl -L https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz | tar xvz
-    cd openshift-origin-clien*
+    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.3/openshift-client-linux.tar.gz | tar xvz
     sudo mv oc kubectl /usr/local/bin/
-    cd ..
     # Start a cluster and login
     oc login ${OC_URL} --token=${OC_TOKEN}
     # Set variables for rest of script to use


### PR DESCRIPTION
**What this PR does / why we need it?**:
- Updated build scripts to stop running e2e on OpenShift 3.11
- Switched `oc` to 4.3

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->

