### PR TITLE
Add some kuttl tests

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+namespace: test-project
+# The default is to run 8 tests in parallel
+# As there is currently only one namespace, this seems bad
+parallel: 1
+#commands:
+#  - command: operator-sdk run --local
+#    background:  true

--- a/test/kuttl/probe/00-assert.yaml
+++ b/test/kuttl/probe/00-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - readinessProbe:
+        initialDelaySeconds: 1
+      livenessProbe:
+        initialDelaySeconds: 4

--- a/test/kuttl/probe/00-runtime-probe.yaml
+++ b/test/kuttl/probe/00-runtime-probe.yaml
@@ -1,0 +1,22 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'navidsh/demo-day'
+  service:
+    type: "ClusterIP"
+    port: 3000
+  replicas: 1
+  livenessProbe:
+    initialDelaySeconds: 4
+    httpGet:
+      path: "/"
+      port: 3000
+  readinessProbe:
+    initialDelaySeconds: 1
+    httpGet:
+      path: "/"
+      port: 3000
+

--- a/test/kuttl/probe/01-assert.yaml
+++ b/test/kuttl/probe/01-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - readinessProbe:
+        initialDelaySeconds: 3
+      livenessProbe:
+        initialDelaySeconds: 6

--- a/test/kuttl/probe/01-runtime-probe.yaml
+++ b/test/kuttl/probe/01-runtime-probe.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  livenessProbe:
+    initialDelaySeconds: 6
+  readinessProbe:
+    initialDelaySeconds: 3
+

--- a/test/kuttl/probe/02-assert.yaml
+++ b/test/kuttl/probe/02-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/probe/02-runtime-probe.yaml
+++ b/test/kuttl/probe/02-runtime-probe.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  livenessProbe: null
+  readinessProbe: null

--- a/test/kuttl/storage/00-assert.yaml
+++ b/test/kuttl/storage/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/storage/00-runtime-storage.yaml
+++ b/test/kuttl/storage/00-runtime-storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+  storage:
+    size: "10Mi"
+    mountPath: "/mnt/data"
+

--- a/test/kuttl/storage/01-assert.yaml
+++ b/test/kuttl/storage/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/storage/01-runtime-no-storage.yaml
+++ b/test/kuttl/storage/01-runtime-no-storage.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+  storage:
+

--- a/test/kuttl/test1/00-assert.yaml
+++ b/test/kuttl/test1/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/test1/00-runtime-basic.yaml
+++ b/test/kuttl/test1/00-runtime-basic.yaml
@@ -1,0 +1,9 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+

--- a/test/kuttl/test1/01-assert.yaml
+++ b/test/kuttl/test1/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 2

--- a/test/kuttl/test1/01-runtime-basic-scale.yaml
+++ b/test/kuttl/test1/01-runtime-basic-scale.yaml
@@ -1,0 +1,7 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  replicas: 2
+


### PR DESCRIPTION
Adds some tests based on the kuttl test framework. These will eventually replace the existing e2e tests, which use the older operator-sdk test framework which is no longer supported

This is part of the work for issue #178