### PR TITLE
Kuttl tests

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+namespace: test-project
+# The default is to run 8 tests in parallel
+# As there is currently only one namespace, this seems bad
+parallel: 1
+#commands:
+#  - command: operator-sdk run --local
+#    background:  true

--- a/test/kuttl/auto1/00-assert.yaml
+++ b/test/kuttl/auto1/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/auto1/00-runtime-basic.yaml
+++ b/test/kuttl/auto1/00-runtime-basic.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1

--- a/test/kuttl/auto1/01-assert.yaml
+++ b/test/kuttl/auto1/01-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-runtime-component
+spec:
+  maxReplicas: 5
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 50

--- a/test/kuttl/auto1/01-runtime-basic.yaml
+++ b/test/kuttl/auto1/01-runtime-basic.yaml
@@ -1,0 +1,12 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  resourceConstraints:
+    requests:
+      cpu: "0.2"
+  autoscaling:
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 50
+

--- a/test/kuttl/auto1/02-assert.yaml
+++ b/test/kuttl/auto1/02-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 2
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-runtime-component
+spec:
+  maxReplicas: 3
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 30

--- a/test/kuttl/auto1/02-update-autoscaling.yaml
+++ b/test/kuttl/auto1/02-update-autoscaling.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  autoscaling:
+    maxReplicas: 3
+    minReplicas: 2
+    targetCPUUtilizationPercentage: 30
+

--- a/test/kuttl/auto1/03-assert.yaml
+++ b/test/kuttl/auto1/03-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 2
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-runtime-component
+spec:
+  maxReplicas: 3
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 30

--- a/test/kuttl/auto1/03-minmax-autoscaling.yaml
+++ b/test/kuttl/auto1/03-minmax-autoscaling.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  autoscaling:
+    maxReplicas: 1
+    minReplicas: 6
+    targetCPUUtilizationPercentage: 10
+

--- a/test/kuttl/auto1/04-assert.yaml
+++ b/test/kuttl/auto1/04-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 2
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-runtime-component
+spec:
+  maxReplicas: 3
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 30

--- a/test/kuttl/auto1/04-autoscaling-boundary.yaml
+++ b/test/kuttl/auto1/04-autoscaling-boundary.yaml
@@ -1,0 +1,12 @@
+# Check that when minReplicas is set to less that one that the update is rejected
+# There should be no change to the existing autoscale resource
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  autoscaling:
+    maxReplicas: 4
+    minReplicas: 0
+    targetCPUUtilizationPercentage: 20
+

--- a/test/kuttl/auto2/00-assert.yaml
+++ b/test/kuttl/auto2/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale2-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/auto2/00-runtime-basic.yaml
+++ b/test/kuttl/auto2/00-runtime-basic.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale2-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1

--- a/test/kuttl/auto2/01-bad-autoscaling.yaml
+++ b/test/kuttl/auto2/01-bad-autoscaling.yaml
@@ -1,0 +1,12 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale2-runtime-component
+spec:
+  resourceConstraints:
+    requests:
+      cpu: "0.2"
+  autoscaling:
+    minReplicas: 5
+    targetCPUUtilizationPercentage: 50
+

--- a/test/kuttl/auto2/01-errors.yaml
+++ b/test/kuttl/auto2/01-errors.yaml
@@ -1,0 +1,4 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: scale2-runtime-component

--- a/test/kuttl/auto3/00-assert.yaml
+++ b/test/kuttl/auto3/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale3-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/auto3/00-runtime-basic.yaml
+++ b/test/kuttl/auto3/00-runtime-basic.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale3-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1

--- a/test/kuttl/auto3/01-add-scaling.yaml
+++ b/test/kuttl/auto3/01-add-scaling.yaml
@@ -1,0 +1,13 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale3-runtime-component
+spec:
+  resourceConstraints:
+    requests:
+      cpu: "0.5"
+  autoscaling:
+    maxReplicas: 5
+    minReplicas: 3
+    targetCPUUtilizationPercentage: 50
+

--- a/test/kuttl/auto3/01-assert.yaml
+++ b/test/kuttl/auto3/01-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale3-runtime-component
+status:
+  readyReplicas: 3
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: scale3-runtime-component
+spec:
+  maxReplicas: 5
+  minReplicas: 3
+  targetCPUUtilizationPercentage: 50

--- a/test/kuttl/auto3/02-assert.yaml
+++ b/test/kuttl/auto3/02-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale3-runtime-component
+status:
+  readyReplicas: 1
+

--- a/test/kuttl/auto3/02-errors.yaml
+++ b/test/kuttl/auto3/02-errors.yaml
@@ -1,0 +1,5 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: scale3-runtime-component
+

--- a/test/kuttl/auto3/02-remove-scaling.yaml
+++ b/test/kuttl/auto3/02-remove-scaling.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale3-runtime-component
+spec:
+  resourceConstraints:
+  autoscaling:
+

--- a/test/kuttl/monitor/00-assert.yaml
+++ b/test/kuttl/monitor/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/monitor/00-errors.yaml
+++ b/test/kuttl/monitor/00-errors.yaml
@@ -1,0 +1,4 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: example-runtime-component

--- a/test/kuttl/monitor/00-runtime-basic.yaml
+++ b/test/kuttl/monitor/00-runtime-basic.yaml
@@ -1,0 +1,13 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'navidsh/demo-day'
+  pullSecret: "regcred"
+  service:
+    type: "ClusterIP"
+    port: 3000
+  replicas: 1
+

--- a/test/kuttl/monitor/01-assert.yaml
+++ b/test/kuttl/monitor/01-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: example-runtime-component
+

--- a/test/kuttl/monitor/01-runtime-basic.yaml
+++ b/test/kuttl/monitor/01-runtime-basic.yaml
@@ -1,0 +1,9 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  monitoring:
+    labels:
+      apps-prometheus: ''
+

--- a/test/kuttl/monitor/02-assert.yaml
+++ b/test/kuttl/monitor/02-assert.yaml
@@ -1,0 +1,46 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: example-runtime-component
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: example-runtime-component
+  endpoints:
+  - path: "/path"
+    scheme: "myScheme"
+    port: 3000-tcp
+    params:
+      params:
+      - param1
+      - param2
+    scrapeTimeout: 10s
+    interval: 30s
+    bearerTokenFile: myBTF
+    tlsConfig:
+      insecureSkipVerify: true
+    basicAuth:
+      password:
+        key: password
+      username:
+        key: username
+---
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  monitoring:
+    endpoints:
+    - path: "/path"

--- a/test/kuttl/monitor/02-runtime-basic.yaml
+++ b/test/kuttl/monitor/02-runtime-basic.yaml
@@ -1,0 +1,24 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  monitoring:
+    endpoints:
+    - path: "/path"
+      scheme: "myScheme"
+      params:
+        params:
+        - "param1"
+        - "param2"
+      interval: "30s"
+      scrapeTimeout: "10s"
+      tlsConfig:
+        insecureSkipVerify: true
+      bearerTokenFile: "myBTF"
+      basicAuth:
+        username:
+          key: "username"
+        password:
+          key: "password"
+      

--- a/test/kuttl/monitor/README.txt
+++ b/test/kuttl/monitor/README.txt
@@ -1,0 +1,3 @@
+This test requires monitoring to be enabled for user projects
+See the Openshift documentation for how to enable this
+https://docs.openshift.com/container-platform/4.6/monitoring/configuring-the-monitoring-stack.html

--- a/test/kuttl/probe/00-assert.yaml
+++ b/test/kuttl/probe/00-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - readinessProbe:
+        initialDelaySeconds: 1
+      livenessProbe:
+        initialDelaySeconds: 4

--- a/test/kuttl/probe/00-runtime-probe.yaml
+++ b/test/kuttl/probe/00-runtime-probe.yaml
@@ -1,0 +1,22 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'navidsh/demo-day'
+  service:
+    type: "ClusterIP"
+    port: 3000
+  replicas: 1
+  livenessProbe:
+    initialDelaySeconds: 4
+    httpGet:
+      path: "/"
+      port: 3000
+  readinessProbe:
+    initialDelaySeconds: 1
+    httpGet:
+      path: "/"
+      port: 3000
+

--- a/test/kuttl/probe/01-assert.yaml
+++ b/test/kuttl/probe/01-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - readinessProbe:
+        initialDelaySeconds: 3
+      livenessProbe:
+        initialDelaySeconds: 6

--- a/test/kuttl/probe/01-runtime-probe.yaml
+++ b/test/kuttl/probe/01-runtime-probe.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  livenessProbe:
+    initialDelaySeconds: 6
+  readinessProbe:
+    initialDelaySeconds: 3
+

--- a/test/kuttl/probe/02-assert.yaml
+++ b/test/kuttl/probe/02-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/probe/02-runtime-probe.yaml
+++ b/test/kuttl/probe/02-runtime-probe.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  livenessProbe: null
+  readinessProbe: null

--- a/test/kuttl/storage/00-assert.yaml
+++ b/test/kuttl/storage/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/storage/00-runtime-storage.yaml
+++ b/test/kuttl/storage/00-runtime-storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+  storage:
+    size: "10Mi"
+    mountPath: "/mnt/data"
+

--- a/test/kuttl/storage/01-assert.yaml
+++ b/test/kuttl/storage/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/storage/01-runtime-no-storage.yaml
+++ b/test/kuttl/storage/01-runtime-no-storage.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+  storage:
+

--- a/test/kuttl/stream/00-assert.yaml
+++ b/test/kuttl/stream/00-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: imagestream-example
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: navidsh/demo-day:v0.1.0
+    name: latest
+status:
+  tags:
+  - tag: latest
+    items:
+    - image: sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823
+

--- a/test/kuttl/stream/00-imagestream.yaml
+++ b/test/kuttl/stream/00-imagestream.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: imagestream-example
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: navidsh/demo-day:v0.1.0
+    name: latest
+

--- a/test/kuttl/stream/01-assert.yaml
+++ b/test/kuttl/stream/01-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+spec:
+  template:
+    spec:
+      containers:
+      - image: navidsh/demo-day@sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: navidsh/demo-day@sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823

--- a/test/kuttl/stream/01-runtime-basic.yaml
+++ b/test/kuttl/stream/01-runtime-basic.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: imagestream-example
+  replicas: 1
+  pullSecret: regcred
+

--- a/test/kuttl/stream/02-assert.yaml
+++ b/test/kuttl/stream/02-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: navidsh/demo-day@sha256:391a9cc130bb96e6b4c3ea0f1c0ac8ae231a5d10a34232e6efd46ab5a6162472

--- a/test/kuttl/stream/02-image-update.yaml
+++ b/test/kuttl/stream/02-image-update.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: imagestream-example
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: navidsh/demo-day:v0.2.0
+    name: latest
+

--- a/test/kuttl/stream/03-assert.yaml
+++ b/test/kuttl/stream/03-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+spec:
+  template:
+    spec:
+      containers:
+      - image: navidsh/demo-day@sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: navidsh/demo-day@sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823

--- a/test/kuttl/stream/03-image-revert.yaml
+++ b/test/kuttl/stream/03-image-revert.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: imagestream-example
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: navidsh/demo-day:v0.1.0
+    name: latest
+

--- a/test/kuttl/stream/04-assert.yaml
+++ b/test/kuttl/stream/04-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+spec:
+  template:
+    spec:
+      containers:
+      - image: navidsh/demo-day
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: navidsh/demo-day

--- a/test/kuttl/stream/04-runtime-no-stream.yaml
+++ b/test/kuttl/stream/04-runtime-no-stream.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: navidsh/demo-day
+

--- a/test/kuttl/stream/05-delete-all.yaml
+++ b/test/kuttl/stream/05-delete-all.yaml
@@ -1,0 +1,8 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+# Delete all image streams in the test namespace
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+- apiVersion: app.stacks/v1beta1
+  kind: RuntimeComponent

--- a/test/kuttl/test1/00-assert.yaml
+++ b/test/kuttl/test1/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/test/kuttl/test1/00-runtime-basic.yaml
+++ b/test/kuttl/test1/00-runtime-basic.yaml
@@ -1,0 +1,9 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+

--- a/test/kuttl/test1/01-assert.yaml
+++ b/test/kuttl/test1/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 2

--- a/test/kuttl/test1/01-runtime-basic-scale.yaml
+++ b/test/kuttl/test1/01-runtime-basic-scale.yaml
@@ -1,0 +1,7 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  replicas: 2
+


### PR DESCRIPTION
Adds some tests based on the kuttl test framework. These will eventually replace the existing e2e tests, which use the older operator-sdk test framework which is no longer supported

This is part of the work for issue #178