### PR TITLE
Issue #168: NodePort value reset for headless service

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -160,7 +160,7 @@ func CustomizeService(svc *corev1.Service, ba common.BaseComponent) {
 		svc.Spec.Ports[0].NodePort = *ba.GetService().GetNodePort()
 	}
 
-	if *ba.GetService().GetType() == corev1.ServiceTypeClusterIP {
+	if *ba.GetService().GetType() == corev1.ServiceTypeClusterIP || strings.HasSuffix(svc.Name, "-headless") == true {
 		svc.Spec.Ports[0].NodePort = 0
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Fixes a bug when a headless service is created with its base service has specified NodePort value and storage
- The NodePort value is set to 0 (default) when the operator is creating a headless service

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #168 
