### PR TITLE
Add e2e tests based on kuttl

### DIFF
--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -47,3 +47,7 @@ stages:
     labels:
       suite: olm
       test: olm-status-descriptors-test
+  - image: quay.io/operator-framework/scorecard-test-kuttl:latest
+    labels:
+      suite: kuttlsuite
+      test: basic-test

--- a/bundle/tests/scorecard/kuttl/auto1/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling1-rc
+status:
+  readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/auto1/00-runtime-basic.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/00-runtime-basic.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: autoscaling1-rc
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1

--- a/bundle/tests/scorecard/kuttl/auto1/01-add-autoscale.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/01-add-autoscale.yaml
@@ -1,0 +1,12 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: autoscaling1-rc
+spec:
+  resourceConstraints:
+    requests:
+      cpu: "0.2"
+  autoscaling:
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 50
+

--- a/bundle/tests/scorecard/kuttl/auto1/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/01-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling1-rc
+status:
+  readyReplicas: 1
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: autoscaling1-rc
+spec:
+  maxReplicas: 5
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 50

--- a/bundle/tests/scorecard/kuttl/auto1/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/02-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling1-rc
+status:
+  readyReplicas: 2
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: autoscaling1-rc
+spec:
+  maxReplicas: 3
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 30

--- a/bundle/tests/scorecard/kuttl/auto1/02-update-autoscaling.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/02-update-autoscaling.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: autoscaling1-rc
+spec:
+  autoscaling:
+    maxReplicas: 3
+    minReplicas: 2
+    targetCPUUtilizationPercentage: 30
+

--- a/bundle/tests/scorecard/kuttl/auto1/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/03-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling1-rc
+status:
+  readyReplicas: 2
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: autoscaling1-rc
+spec:
+  maxReplicas: 3
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 30

--- a/bundle/tests/scorecard/kuttl/auto1/03-minmax-autoscaling.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/03-minmax-autoscaling.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: autoscaling1-rc
+spec:
+  autoscaling:
+    maxReplicas: 1
+    minReplicas: 6
+    targetCPUUtilizationPercentage: 10
+

--- a/bundle/tests/scorecard/kuttl/auto1/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/04-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling1-rc
+status:
+  readyReplicas: 2
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: autoscaling1-rc
+spec:
+  maxReplicas: 3
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 30

--- a/bundle/tests/scorecard/kuttl/auto1/04-autoscaling-boundary.yaml
+++ b/bundle/tests/scorecard/kuttl/auto1/04-autoscaling-boundary.yaml
@@ -1,0 +1,12 @@
+# Check that when minReplicas is set to less that one that the update is rejected
+# There should be no change to the existing autoscale resource
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: autoscaling1-rc
+spec:
+  autoscaling:
+    maxReplicas: 4
+    minReplicas: 0
+    targetCPUUtilizationPercentage: 20
+

--- a/bundle/tests/scorecard/kuttl/auto2/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto2/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale2-runtime-component
+status:
+  readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/auto2/00-runtime-basic.yaml
+++ b/bundle/tests/scorecard/kuttl/auto2/00-runtime-basic.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale2-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1

--- a/bundle/tests/scorecard/kuttl/auto2/01-bad-autoscaling.yaml
+++ b/bundle/tests/scorecard/kuttl/auto2/01-bad-autoscaling.yaml
@@ -1,0 +1,14 @@
+# Not all required fields are set, so autoscaling
+# should not be enabled
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale2-runtime-component
+spec:
+  resourceConstraints:
+    requests:
+      cpu: "0.2"
+  autoscaling:
+    minReplicas: 5
+    targetCPUUtilizationPercentage: 50
+

--- a/bundle/tests/scorecard/kuttl/auto2/01-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/auto2/01-errors.yaml
@@ -1,0 +1,4 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: scale2-runtime-component

--- a/bundle/tests/scorecard/kuttl/auto3/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale3-runtime-component
+status:
+  readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/auto3/00-runtime-basic.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/00-runtime-basic.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale3-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1

--- a/bundle/tests/scorecard/kuttl/auto3/01-add-scaling.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/01-add-scaling.yaml
@@ -1,0 +1,13 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale3-runtime-component
+spec:
+  resourceConstraints:
+    requests:
+      cpu: "0.5"
+  autoscaling:
+    maxReplicas: 5
+    minReplicas: 3
+    targetCPUUtilizationPercentage: 50
+

--- a/bundle/tests/scorecard/kuttl/auto3/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/01-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale3-runtime-component
+status:
+  readyReplicas: 3
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: scale3-runtime-component
+spec:
+  maxReplicas: 5
+  minReplicas: 3
+  targetCPUUtilizationPercentage: 50

--- a/bundle/tests/scorecard/kuttl/auto3/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/02-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scale3-runtime-component
+status:
+  readyReplicas: 1
+

--- a/bundle/tests/scorecard/kuttl/auto3/02-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/02-errors.yaml
@@ -1,0 +1,5 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: scale3-runtime-component
+

--- a/bundle/tests/scorecard/kuttl/auto3/02-remove-scaling.yaml
+++ b/bundle/tests/scorecard/kuttl/auto3/02-remove-scaling.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: scale3-runtime-component
+spec:
+  resourceConstraints:
+  autoscaling:
+

--- a/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/basic/00-runtime-basic.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/00-runtime-basic.yaml
@@ -1,0 +1,9 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+

--- a/bundle/tests/scorecard/kuttl/basic/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-runtime-component
+status:
+  readyReplicas: 2

--- a/bundle/tests/scorecard/kuttl/basic/01-runtime-basic-scale.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/01-runtime-basic-scale.yaml
@@ -1,0 +1,7 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: example-runtime-component
+spec:
+  replicas: 2
+

--- a/bundle/tests/scorecard/kuttl/knative/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/knative/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knative1-rc
+status:
+  readyReplicas: 1
+

--- a/bundle/tests/scorecard/kuttl/knative/00-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/knative/00-errors.yaml
@@ -1,0 +1,5 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: knative1-rc
+

--- a/bundle/tests/scorecard/kuttl/knative/00-runtime-no-knative.yaml
+++ b/bundle/tests/scorecard/kuttl/knative/00-runtime-no-knative.yaml
@@ -1,0 +1,12 @@
+# Check that when the createKnativeService field exists but
+# is set to false, no knative service is created
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: knative1-rc
+spec:
+  # Add fields here
+  applicationImage: navidsh/demo-day
+  replicas: 1
+  createKnativeService: false
+

--- a/bundle/tests/scorecard/kuttl/knative/01-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/knative/01-delete.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+# Delete all RuntimeComponents in the test namespace
+- apiVersion: app.stacks/v1beta1
+  kind: RuntimeComponent

--- a/bundle/tests/scorecard/kuttl/knative2/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/knative2/00-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: knative2-rc
+

--- a/bundle/tests/scorecard/kuttl/knative2/00-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/knative2/00-errors.yaml
@@ -1,0 +1,6 @@
+# There shouldn't be a deployment if there is a knative service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knative2-rc
+

--- a/bundle/tests/scorecard/kuttl/knative2/00-runtime-knative.yaml
+++ b/bundle/tests/scorecard/kuttl/knative2/00-runtime-knative.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: knative2-rc
+spec:
+  # Add fields here
+  applicationImage: navidsh/demo-day
+  replicas: 1
+  createKnativeService: true
+

--- a/bundle/tests/scorecard/kuttl/knative2/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/knative2/01-assert.yaml
@@ -1,0 +1,9 @@
+# There shouldn't be a deployment if there is a knative service
+# This should only be created when the knative service is removed
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knative2-rc
+status:
+  readyReplicas: 1
+

--- a/bundle/tests/scorecard/kuttl/knative2/01-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/knative2/01-errors.yaml
@@ -1,0 +1,5 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: knative2-rc
+

--- a/bundle/tests/scorecard/kuttl/knative2/01-runtime-remove-knative.yaml
+++ b/bundle/tests/scorecard/kuttl/knative2/01-runtime-remove-knative.yaml
@@ -1,0 +1,12 @@
+# Check that the knative service is removed when the appropriate
+# field is updated to false
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: knative2-rc
+spec:
+  # Add fields here
+  applicationImage: navidsh/demo-day
+  replicas: 1
+  createKnativeService: false
+

--- a/bundle/tests/scorecard/kuttl/kuttl-test.yaml
+++ b/bundle/tests/scorecard/kuttl/kuttl-test.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+parallel: 1
+timeout: 120
+startControlPlane: false

--- a/bundle/tests/scorecard/kuttl/monitor/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-monitor-rc
+status:
+  readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/monitor/00-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/00-errors.yaml
@@ -1,0 +1,4 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: service-monitor-rc

--- a/bundle/tests/scorecard/kuttl/monitor/00-runtime-basic.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/00-runtime-basic.yaml
@@ -1,0 +1,12 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: service-monitor-rc
+spec:
+  # Add fields here
+  applicationImage: 'navidsh/demo-day'
+  service:
+    type: "ClusterIP"
+    port: 3000
+  replicas: 1
+

--- a/bundle/tests/scorecard/kuttl/monitor/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/01-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-monitor-rc
+status:
+  readyReplicas: 1
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: service-monitor-rc
+

--- a/bundle/tests/scorecard/kuttl/monitor/01-runtime-add-monitor.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/01-runtime-add-monitor.yaml
@@ -1,0 +1,11 @@
+# Adding a label should be sufficient to cause the operator
+# to create the monitor
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: service-monitor-rc
+spec:
+  monitoring:
+    labels:
+      apps-prometheus: ''
+

--- a/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
@@ -1,0 +1,46 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-monitor-rc
+status:
+  readyReplicas: 1
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: service-monitor-rc
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: service-monitor-rc
+  endpoints:
+  - path: "/path"
+    scheme: "myScheme"
+    port: 3000-tcp
+    params:
+      params:
+      - param1
+      - param2
+    scrapeTimeout: 10s
+    interval: 30s
+    bearerTokenFile: myBTF
+    tlsConfig:
+      insecureSkipVerify: true
+    basicAuth:
+      password:
+        key: password
+      username:
+        key: username
+---
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: service-monitor-rc
+spec:
+  monitoring:
+    endpoints:
+    - path: "/path"

--- a/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
@@ -35,12 +35,4 @@ spec:
         key: password
       username:
         key: username
----
-apiVersion: app.stacks/v1beta1
-kind: RuntimeComponent
-metadata:
-  name: service-monitor-rc
-spec:
-  monitoring:
-    endpoints:
-    - path: "/path"
+

--- a/bundle/tests/scorecard/kuttl/monitor/02-runtime-update-monitor.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-runtime-update-monitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: service-monitor-rc
+spec:
+  monitoring:
+    endpoints:
+    - path: "/path"
+      scheme: "myScheme"
+      params:
+        params:
+        - "param1"
+        - "param2"
+      interval: "30s"
+      scrapeTimeout: "10s"
+      tlsConfig:
+        insecureSkipVerify: true
+      bearerTokenFile: "myBTF"
+      basicAuth:
+        username:
+          key: "username"
+        password:
+          key: "password"
+      

--- a/bundle/tests/scorecard/kuttl/monitor/README.txt
+++ b/bundle/tests/scorecard/kuttl/monitor/README.txt
@@ -1,0 +1,3 @@
+This test requires monitoring to be enabled for user projects
+See the Openshift documentation for how to enable this
+https://docs.openshift.com/container-platform/4.6/monitoring/configuring-the-monitoring-stack.html

--- a/bundle/tests/scorecard/kuttl/probe/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/00-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: probes-rc
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - readinessProbe:
+        initialDelaySeconds: 1
+      livenessProbe:
+        initialDelaySeconds: 4

--- a/bundle/tests/scorecard/kuttl/probe/00-runtime-probe.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/00-runtime-probe.yaml
@@ -1,0 +1,22 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: probes-rc
+spec:
+  # Add fields here
+  applicationImage: 'navidsh/demo-day'
+  service:
+    type: "ClusterIP"
+    port: 3000
+  replicas: 1
+  livenessProbe:
+    initialDelaySeconds: 4
+    httpGet:
+      path: "/"
+      port: 3000
+  readinessProbe:
+    initialDelaySeconds: 1
+    httpGet:
+      path: "/"
+      port: 3000
+

--- a/bundle/tests/scorecard/kuttl/probe/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/01-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: probes-rc
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - readinessProbe:
+        initialDelaySeconds: 3
+      livenessProbe:
+        initialDelaySeconds: 6

--- a/bundle/tests/scorecard/kuttl/probe/01-runtime-update-probe.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/01-runtime-update-probe.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: probes-rc
+spec:
+  livenessProbe:
+    initialDelaySeconds: 6
+  readinessProbe:
+    initialDelaySeconds: 3
+

--- a/bundle/tests/scorecard/kuttl/probe/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/02-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: probes-rc
+status:
+  readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/02-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/02-errors.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - readinessProbe:
+        initialDelaySeconds: 3
+      livenessProbe:
+        initialDelaySeconds: 6

--- a/bundle/tests/scorecard/kuttl/probe/02-runtime-remove-probe.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/02-runtime-remove-probe.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: probes-rc
+spec:
+  # Add fields here
+  livenessProbe: null
+  readinessProbe: null

--- a/bundle/tests/scorecard/kuttl/storage/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: storage-rc
+status:
+  readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/storage/00-runtime-storage.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/00-runtime-storage.yaml
@@ -1,0 +1,14 @@
+# With some storage configured, the operator
+# should create a stateful set
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: storage-rc
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+  storage:
+    size: "10Mi"
+    mountPath: "/mnt/data"
+

--- a/bundle/tests/scorecard/kuttl/storage/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: storage-rc
+status:
+  readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/storage/01-runtime-no-storage.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/01-runtime-no-storage.yaml
@@ -1,0 +1,12 @@
+# Removing the storage, and the operator should
+# move from a stateful set back to a deployment
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: storage-rc
+spec:
+  # Add fields here
+  applicationImage: 'k8s.gcr.io/pause:2.0'
+  replicas: 1
+  storage:
+

--- a/bundle/tests/scorecard/kuttl/storage/README.txt
+++ b/bundle/tests/scorecard/kuttl/storage/README.txt
@@ -1,0 +1,2 @@
+In order to run this test, the cluster must
+have a storage class enabled

--- a/bundle/tests/scorecard/kuttl/stream/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/00-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: imagestream-example
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: navidsh/demo-day:v0.1.0
+    name: latest
+status:
+  tags:
+  - tag: latest
+    items:
+    - image: sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823
+

--- a/bundle/tests/scorecard/kuttl/stream/00-imagestream.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/00-imagestream.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: imagestream-example
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: navidsh/demo-day:v0.1.0
+    name: latest
+

--- a/bundle/tests/scorecard/kuttl/stream/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/01-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imagestream-rc
+spec:
+  template:
+    spec:
+      containers:
+      - image: navidsh/demo-day@sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: navidsh/demo-day@sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823

--- a/bundle/tests/scorecard/kuttl/stream/01-runtime-basic.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/01-runtime-basic.yaml
@@ -1,0 +1,9 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: imagestream-rc
+spec:
+  # Add fields here
+  applicationImage: imagestream-example
+  replicas: 1
+

--- a/bundle/tests/scorecard/kuttl/stream/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/02-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imagestream-rc
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: navidsh/demo-day@sha256:391a9cc130bb96e6b4c3ea0f1c0ac8ae231a5d10a34232e6efd46ab5a6162472

--- a/bundle/tests/scorecard/kuttl/stream/02-image-update.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/02-image-update.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: imagestream-example
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: navidsh/demo-day:v0.2.0
+    name: latest
+

--- a/bundle/tests/scorecard/kuttl/stream/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/03-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imagestream-rc
+spec:
+  template:
+    spec:
+      containers:
+      - image: navidsh/demo-day@sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: navidsh/demo-day@sha256:b441e81a681df8fdf6922f00318fb78d15dea7f24823eef58b2480aa84aba823

--- a/bundle/tests/scorecard/kuttl/stream/03-image-revert.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/03-image-revert.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: imagestream-example
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: navidsh/demo-day:v0.1.0
+    name: latest
+

--- a/bundle/tests/scorecard/kuttl/stream/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/04-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imagestream-rc
+spec:
+  template:
+    spec:
+      containers:
+      - image: navidsh/demo-day
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: navidsh/demo-day

--- a/bundle/tests/scorecard/kuttl/stream/04-runtime-no-stream.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/04-runtime-no-stream.yaml
@@ -1,0 +1,8 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: imagestream-rc
+spec:
+  # Add fields here
+  applicationImage: navidsh/demo-day
+

--- a/bundle/tests/scorecard/kuttl/stream/05-delete-all.yaml
+++ b/bundle/tests/scorecard/kuttl/stream/05-delete-all.yaml
@@ -1,0 +1,11 @@
+# Kuttl doesn't seem to delete all the resources from this
+# test consistently. This step is here just to force
+# the cleanup.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+# Delete all image streams in the test namespace
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+- apiVersion: app.stacks/v1beta1
+  kind: RuntimeComponent


### PR DESCRIPTION
Adds some tests based on the kuttl test framework. These will eventually replace the existing e2e tests, which use the older operator-sdk test framework which is no longer supported

This is part of the work for issue #178