### PR TITLE
Issue #188: Adding Startup Probe support and changes to user guide document

### DIFF
--- a/api/v1beta1/runtimecomponent_types.go
+++ b/api/v1beta1/runtimecomponent_types.go
@@ -45,6 +45,7 @@ type RuntimeComponentSpec struct {
 	ResourceConstraints *corev1.ResourceRequirements `json:"resourceConstraints,omitempty"`
 	ReadinessProbe      *corev1.Probe                `json:"readinessProbe,omitempty"`
 	LivenessProbe       *corev1.Probe                `json:"livenessProbe,omitempty"`
+	StartupProbe        *corev1.Probe                `json:"startupProbe,omitempty"`
 	Service             *RuntimeComponentService     `json:"service,omitempty"`
 	Expose              *bool                        `json:"expose,omitempty"`
 	// +listType=atomic
@@ -270,6 +271,11 @@ func (cr *RuntimeComponent) GetLivenessProbe() *corev1.Probe {
 // GetReadinessProbe returns readiness probe
 func (cr *RuntimeComponent) GetReadinessProbe() *corev1.Probe {
 	return cr.Spec.ReadinessProbe
+}
+
+// GetStartupProbe returns startup probe
+func (cr *RuntimeComponent) GetStartupProbe() *corev1.Probe {
+	return cr.Spec.StartupProbe
 }
 
 // GetVolumes returns volumes slice

--- a/common/types.go
+++ b/common/types.go
@@ -167,6 +167,7 @@ type BaseComponent interface {
 	GetReplicas() *int32
 	GetLivenessProbe() *corev1.Probe
 	GetReadinessProbe() *corev1.Probe
+	GetStartupProbe() *corev1.Probe
 	GetVolumes() []corev1.Volume
 	GetVolumeMounts() []corev1.VolumeMount
 	GetResourceConstraints() *corev1.ResourceRequirements

--- a/doc/user-guide.adoc
+++ b/doc/user-guide.adoc
@@ -99,8 +99,9 @@ Each `RuntimeComponent` CR must at least specify the `applicationImage` paramete
 | `resourceConstraints.limits.memory` | The memory upper limit in bytes. Specify integers with suffixes: E, P, T, G, M, K, or power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
 | `env`   | An array of environment variables following the format of `{name, value}`, where value is a simple string. It may also follow the format of `{name, valueFrom}`, where valueFrom refers to a value in a `ConfigMap` or `Secret` resource. See link:++#environment-variables++[Environment variables] for more info.
 | `envFrom`   | An array of references to `ConfigMap` or `Secret` resources containing environment variables. Keys from `ConfigMap` or `Secret` resources become environment variable names in your container. See link:++#environment-variables++[Environment variables] for more info.
-| `readinessProbe`   | A YAML object configuring the link:++https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes++[Kubernetes readiness probe] that controls when the pod is ready to receive traffic.
-| `livenessProbe` | A YAML object configuring the link:++https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request++[Kubernetes liveness probe] that controls when Kubernetes needs to restart the pod.
+| `readinessProbe`   | A YAML object configuring the link:++https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes++[Kubernetes readiness probe] that controls when the pod is ready to receive traffic.
+| `livenessProbe` | A YAML object configuring the link:++https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request++[Kubernetes liveness probe] that controls when Kubernetes needs to restart the pod.
+| `startupProbe` | A YAML object configuring the link:++https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes++[Kubernetes startup probe] that controls when Kubernetes needs to startup the pod on its first initialization.
 | `volumes` | A YAML object that represents a link:++https://kubernetes.io/docs/concepts/storage/volumes++[pod volume].
 | `volumeMounts` | A YAML object that represents a link:++https://kubernetes.io/docs/concepts/storage/volumes/++[pod volumeMount].
 | `storage.size` | A convenient field to set the size of the persisted storage. Can be overridden by the `storage.volumeClaimTemplate` property.
@@ -627,7 +628,7 @@ spec:
 
 By setting this parameter, the operator creates a Knative service in the cluster and populates the resource with applicable `RuntimeComponent` fields. Also, it ensures non-Knative resources including Kubernetes `Service`, `Route`, `Deployment` and etc. are deleted.
 
-The CRD fields which are used to populate the Knative service resource include `applicationImage`, `serviceAccountName`, `livenessProbe`, `readinessProbe`, `service.Port`, `volumes`, `volumeMounts`, `env`, `envFrom`, `pullSecret` and `pullPolicy`.
+The CRD fields which are used to populate the Knative service resource include `applicationImage`, `serviceAccountName`, `livenessProbe`, `readinessProbe`, `service.Port`, `volumes`, `volumeMounts`, `env`, `envFrom`, `pullSecret` and `pullPolicy`. `startupProbe` is not fully supported by Knative and it will not apply when Knative service is enabled.
 
 For more details on how to configure Knative for tasks such as enabling HTTPS connections and setting up a custom domain, checkout link:++https://knative.dev/docs/serving/++[Knative Documentation].
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -381,6 +381,7 @@ func CustomizePodSpec(pts *corev1.PodTemplateSpec, ba common.BaseComponent) {
 	}
 	appContainer.ReadinessProbe = ba.GetReadinessProbe()
 	appContainer.LivenessProbe = ba.GetLivenessProbe()
+	appContainer.StartupProbe = ba.GetStartupProbe()
 
 	if ba.GetPullPolicy() != nil {
 		appContainer.ImagePullPolicy = *ba.GetPullPolicy()
@@ -616,6 +617,7 @@ func CustomizeKnativeService(ksvc *servingv1.Service, ba common.BaseComponent) {
 	//ksvc.Spec.Template.Spec.Containers[0].Resources = *cr.Spec.ResourceConstraints
 	ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe = ba.GetReadinessProbe()
 	ksvc.Spec.Template.Spec.Containers[0].LivenessProbe = ba.GetLivenessProbe()
+	ksvc.Spec.Template.Spec.Containers[0].StartupProbe = ba.GetStartupProbe()
 	ksvc.Spec.Template.Spec.Containers[0].ImagePullPolicy = *ba.GetPullPolicy()
 	ksvc.Spec.Template.Spec.Containers[0].Env = ba.GetEnv()
 	ksvc.Spec.Template.Spec.Containers[0].EnvFrom = ba.GetEnvFrom()
@@ -645,6 +647,15 @@ func CustomizeKnativeService(ksvc *servingv1.Service, ba common.BaseComponent) {
 		}
 		if ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket != nil {
 			ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port = intstr.IntOrString{}
+		}
+	}
+
+	if ksvc.Spec.Template.Spec.Containers[0].StartupProbe != nil {
+		if ksvc.Spec.Template.Spec.Containers[0].StartupProbe.HTTPGet != nil {
+			ksvc.Spec.Template.Spec.Containers[0].StartupProbe.HTTPGet.Port = intstr.IntOrString{}
+		}
+		if ksvc.Spec.Template.Spec.Containers[0].StartupProbe.TCPSocket != nil {
+			ksvc.Spec.Template.Spec.Containers[0].StartupProbe.TCPSocket.Port = intstr.IntOrString{}
 		}
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -60,6 +60,12 @@ var (
 			TCPSocket: &corev1.TCPSocketAction{},
 		},
 	}
+	startupProbe = &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet:   &corev1.HTTPGetAction{},
+			TCPSocket: &corev1.TCPSocketAction{},
+		},
+	}
 	volume      = corev1.Volume{Name: "runtime-volume"}
 	volumeMount = corev1.VolumeMount{Name: volumeCT.Name, MountPath: storage.MountPath}
 	resLimits   = map[corev1.ResourceName]resource.Quantity{
@@ -276,6 +282,7 @@ func TestCustomizePodSpec(t *testing.T) {
 		ResourceConstraints: resourceContraints,
 		ReadinessProbe:      readinessProbe,
 		LivenessProbe:       livenessProbe,
+		StartupProbe:        startupProbe,
 		VolumeMounts:        []corev1.VolumeMount{volumeMount},
 		PullPolicy:          &pullPolicy,
 		Env:                 env,
@@ -299,6 +306,7 @@ func TestCustomizePodSpec(t *testing.T) {
 		ResourceConstraints: resourceContraints,
 		ReadinessProbe:      readinessProbe,
 		LivenessProbe:       livenessProbe,
+		StartupProbe:        startupProbe,
 		VolumeMounts:        []corev1.VolumeMount{volumeMount},
 		PullPolicy:          &pullPolicy,
 		Env:                 env,
@@ -397,6 +405,7 @@ func TestCustomizeKnativeService(t *testing.T) {
 		Service:          service,
 		LivenessProbe:    livenessProbe,
 		ReadinessProbe:   readinessProbe,
+		StartupProbe:     startupProbe,
 		PullPolicy:       &pullPolicy,
 		Env:              env,
 		EnvFrom:          envFrom,
@@ -412,6 +421,8 @@ func TestCustomizeKnativeService(t *testing.T) {
 	ksvcLPTCP := ksvc.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket.Port
 	ksvcRPPort := ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port
 	ksvcRPTCP := ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port
+	ksvcSPPort := ksvc.Spec.Template.Spec.Containers[0].StartupProbe.HTTPGet.Port
+	ksvcSPTCP := ksvc.Spec.Template.Spec.Containers[0].StartupProbe.TCPSocket.Port
 	ksvcLabelNoExpose := ksvc.Labels["serving.knative.dev/visibility"]
 
 	spec = appstacksv1beta1.RuntimeComponentSpec{
@@ -424,6 +435,7 @@ func TestCustomizeKnativeService(t *testing.T) {
 		ServiceAccountName: &serviceAccountName,
 		LivenessProbe:      livenessProbe,
 		ReadinessProbe:     readinessProbe,
+		StartupProbe:       startupProbe,
 		Expose:             &expose,
 	}
 	runtime = createRuntimeComponent(name, namespace, spec)
@@ -443,6 +455,8 @@ func TestCustomizeKnativeService(t *testing.T) {
 		{"liveness probe TCP socket port", intstr.IntOrString{}, ksvcLPTCP},
 		{"Readiness probe port", intstr.IntOrString{}, ksvcRPPort},
 		{"Readiness probe TCP socket port", intstr.IntOrString{}, ksvcRPTCP},
+		{"Startup probe port", intstr.IntOrString{}, ksvcSPPort},
+		{"Startup probe TCP socket port", intstr.IntOrString{}, ksvcSPTCP},
 		{"expose not set", "cluster-local", ksvcLabelNoExpose},
 		{"expose set to true", "", ksvcLabelTrueExpose},
 		{"expose set to false", "cluster-local", ksvcLabelFalseExpose},


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Adding startup probe support in v1beta1 version of operator
- Editing user guide doc for startup probe usage and its support on Knative

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [x] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #188
Fixes https://github.com/OpenLiberty/open-liberty-operator/issues/215
