### PR TITLE
Issue #195: StatefulSet creation without PVC for each instance

### DIFF
--- a/api/v1beta1/runtimecomponent_types.go
+++ b/api/v1beta1/runtimecomponent_types.go
@@ -62,7 +62,6 @@ type RuntimeComponentSpec struct {
 
 	// +listType=set
 	Architecture         []string                    `json:"architecture,omitempty"`
-	Storage              *RuntimeComponentStorage    `json:"storage,omitempty"`
 	CreateKnativeService *bool                       `json:"createKnativeService,omitempty"`
 	Monitoring           *RuntimeComponentMonitoring `json:"monitoring,omitempty"`
 	ApplicationName      string                      `json:"applicationName,omitempty"`
@@ -131,6 +130,7 @@ type RuntimeComponentDeployment struct {
 // RuntimeComponentStatefulSet settings
 type RuntimeComponentStatefulSet struct {
 	UpdateStrategy *appsv1.StatefulSetUpdateStrategy `json:"updateStrategy,omitempty"`
+	Storage        *RuntimeComponentStorage          `json:"storage,omitempty"`
 }
 
 // ServiceBindingProvides represents information about
@@ -341,11 +341,11 @@ func (cr *RuntimeComponent) GetAutoscaling() common.BaseComponentAutoscaling {
 }
 
 // GetStorage returns storage settings
-func (cr *RuntimeComponent) GetStorage() common.BaseComponentStorage {
-	if cr.Spec.Storage == nil {
+func (ss *RuntimeComponentStatefulSet) GetStorage() common.BaseComponentStorage {
+	if ss.Storage == nil {
 		return nil
 	}
-	return cr.Spec.Storage
+	return ss.Storage
 }
 
 // GetService returns service settings

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -471,11 +471,6 @@ func (in *RuntimeComponentSpec) DeepCopyInto(out *RuntimeComponentSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.Storage != nil {
-		in, out := &in.Storage, &out.Storage
-		*out = new(RuntimeComponentStorage)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.CreateKnativeService != nil {
 		in, out := &in.CreateKnativeService, &out.CreateKnativeService
 		*out = new(bool)
@@ -533,6 +528,11 @@ func (in *RuntimeComponentStatefulSet) DeepCopyInto(out *RuntimeComponentStatefu
 	if in.UpdateStrategy != nil {
 		in, out := &in.UpdateStrategy, &out.UpdateStrategy
 		*out = new(appsv1.StatefulSetUpdateStrategy)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = new(RuntimeComponentStorage)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/bundle/manifests/app.stacks_runtimecomponents.yaml
+++ b/bundle/manifests/app.stacks_runtimecomponents.yaml
@@ -2723,6 +2723,164 @@ spec:
               statefulSet:
                 description: RuntimeComponentStatefulSet settings
                 properties:
+                  storage:
+                    description: RuntimeComponentStorage ...
+                    properties:
+                      mountPath:
+                        type: string
+                      size:
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                        type: string
+                      volumeClaimTemplate:
+                        description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          metadata:
+                            description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            type: object
+                          spec:
+                            description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              dataSource:
+                                description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              resources:
+                                description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                              selector:
+                                description: A label query over volumes to consider for binding.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                type: string
+                            type: object
+                          status:
+                            description: 'Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              capacity:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: Represents the actual resources of the underlying volume.
+                                type: object
+                              conditions:
+                                description: Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                                items:
+                                  description: PersistentVolumeClaimCondition contails details about state of pvc
+                                  properties:
+                                    lastProbeTime:
+                                      description: Last time we probed the condition.
+                                      format: date-time
+                                      type: string
+                                    lastTransitionTime:
+                                      description: Last time the condition transitioned from one status to another.
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Human-readable message indicating details about last transition.
+                                      type: string
+                                    reason:
+                                      description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
+                                      type: string
+                                  required:
+                                  - status
+                                  - type
+                                  type: object
+                                type: array
+                              phase:
+                                description: Phase represents the current phase of PersistentVolumeClaim.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
                   updateStrategy:
                     description: StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.
                     properties:
@@ -2737,164 +2895,6 @@ spec:
                       type:
                         description: Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
                         type: string
-                    type: object
-                type: object
-              storage:
-                description: RuntimeComponentStorage ...
-                properties:
-                  mountPath:
-                    type: string
-                  size:
-                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                    type: string
-                  volumeClaimTemplate:
-                    description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
-                    properties:
-                      apiVersion:
-                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                        type: string
-                      kind:
-                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        type: object
-                      spec:
-                        description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          accessModes:
-                            description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                            items:
-                              type: string
-                            type: array
-                          dataSource:
-                            description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
-                            properties:
-                              apiGroup:
-                                description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
-                                type: string
-                              kind:
-                                description: Kind is the type of resource being referenced
-                                type: string
-                              name:
-                                description: Name is the name of resource being referenced
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                          resources:
-                            description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                            type: object
-                          selector:
-                            description: A label query over volumes to consider for binding.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          storageClassName:
-                            description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                            type: string
-                          volumeMode:
-                            description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
-                            type: string
-                          volumeName:
-                            description: VolumeName is the binding reference to the PersistentVolume backing this claim.
-                            type: string
-                        type: object
-                      status:
-                        description: 'Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          accessModes:
-                            description: 'AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                            items:
-                              type: string
-                            type: array
-                          capacity:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: Represents the actual resources of the underlying volume.
-                            type: object
-                          conditions:
-                            description: Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
-                            items:
-                              description: PersistentVolumeClaimCondition contails details about state of pvc
-                              properties:
-                                lastProbeTime:
-                                  description: Last time we probed the condition.
-                                  format: date-time
-                                  type: string
-                                lastTransitionTime:
-                                  description: Last time the condition transitioned from one status to another.
-                                  format: date-time
-                                  type: string
-                                message:
-                                  description: Human-readable message indicating details about last transition.
-                                  type: string
-                                reason:
-                                  description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
-                                  type: string
-                                status:
-                                  type: string
-                                type:
-                                  description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
-                                  type: string
-                              required:
-                              - status
-                              - type
-                              type: object
-                            type: array
-                          phase:
-                            description: Phase represents the current phase of PersistentVolumeClaim.
-                            type: string
-                        type: object
                     type: object
                 type: object
               version:

--- a/bundle/tests/scorecard/kuttl/kubeconfig
+++ b/bundle/tests/scorecard/kuttl/kubeconfig
@@ -1,0 +1,16 @@
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://9.30.235.22:6443
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    user: user
+  name: cluster
+current-context: cluster
+preferences: {}
+users:
+- name: user
+  user:
+    token: sha256~gZW_7m9oHpc1DtWaYzSLzDEL0xk1JqhyFDZmrvy6eII

--- a/bundle/tests/scorecard/kuttl/out.txt
+++ b/bundle/tests/scorecard/kuttl/out.txt
@@ -1,0 +1,21 @@
+=== RUN   kuttl
+    harness.go:457: starting setup
+    harness.go:248: running tests using configured kubeconfig.
+    harness.go:285: Successful connection to cluster at: https://9.30.235.22:6443
+    harness.go:353: running tests
+    harness.go:74: going to run test suite with timeout of 300 seconds for each step
+    harness.go:365: testsuite: ./ has 13 tests
+=== RUN   kuttl/harness
+=== RUN   kuttl/harness/persistent-storage
+=== PAUSE kuttl/harness/persistent-storage
+=== RUN   kuttl/harness/teststorage
+=== PAUSE kuttl/harness/teststorage
+=== CONT  kuttl/harness/persistent-storage
+    logger.go:42: 14:49:53 | persistent-storage | Ignoring README.txt as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
+    logger.go:42: 14:49:53 | persistent-storage | Skipping creation of user-supplied namespace: operator-test
+    logger.go:42: 14:49:53 | persistent-storage/0-persistent-storage-rc | starting test step 0-persistent-storage-rc
+    logger.go:42: 14:49:57 | persistent-storage/0-persistent-storage-rc | RuntimeComponent:operator-test/persistent-rc created
+=== CONT  kuttl
+    harness.go:508: cleaning up
+    harness.go:563: removing temp folder: ""
+    harness.go:444: failed with interrupt

--- a/bundle/tests/scorecard/kuttl/persistent-storage/00-persistent-storage-rc.yaml
+++ b/bundle/tests/scorecard/kuttl/persistent-storage/00-persistent-storage-rc.yaml
@@ -8,12 +8,13 @@ spec:
   volumeMounts:
     - name: pvc
       mountPath: /data
-  storage:
-    volumeClaimTemplate:
-      metadata:
-        name: pvc
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 15Mi
+  statefulSet:
+    storage:
+      volumeClaimTemplate:
+        metadata:
+          name: pvc
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 15Mi

--- a/bundle/tests/scorecard/kuttl/persistent-storage/01-no-storage-rc.yaml
+++ b/bundle/tests/scorecard/kuttl/persistent-storage/01-no-storage-rc.yaml
@@ -6,4 +6,4 @@ spec:
   applicationImage: navidsh/demo-day
   replicas: 1
   volumeMounts:
-  storage:
+  statefulSet:

--- a/bundle/tests/scorecard/kuttl/storage/00-runtime-storage.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/00-runtime-storage.yaml
@@ -8,7 +8,8 @@ spec:
   # Add fields here
   applicationImage: 'k8s.gcr.io/pause:2.0'
   replicas: 1
-  storage:
-    size: "10Mi"
-    mountPath: "/mnt/data"
+  statefulSet:
+    storage:
+      size: "10Mi"
+      mountPath: "/mnt/data"
 

--- a/bundle/tests/scorecard/kuttl/storage/01-runtime-no-storage.yaml
+++ b/bundle/tests/scorecard/kuttl/storage/01-runtime-no-storage.yaml
@@ -8,5 +8,5 @@ spec:
   # Add fields here
   applicationImage: 'k8s.gcr.io/pause:2.0'
   replicas: 1
-  storage:
+  statefulSet:
 

--- a/common/types.go
+++ b/common/types.go
@@ -164,6 +164,7 @@ type BaseComponentDeployment interface {
 // BaseComponentStatefulSet describes deployment
 type BaseComponentStatefulSet interface {
 	GetStatefulSetUpdateStrategy() *appsv1.StatefulSetUpdateStrategy
+	GetStorage() BaseComponentStorage
 }
 
 // BaseComponent represents basic kubernetes application
@@ -185,7 +186,6 @@ type BaseComponent interface {
 	GetCreateKnativeService() *bool
 	GetArchitecture() []string
 	GetAutoscaling() BaseComponentAutoscaling
-	GetStorage() BaseComponentStorage
 	GetService() BaseComponentService
 	GetDeployment() BaseComponentDeployment
 	GetStatefulSet() BaseComponentStatefulSet

--- a/config/crd/bases/app.stacks_runtimecomponents.yaml
+++ b/config/crd/bases/app.stacks_runtimecomponents.yaml
@@ -3968,6 +3968,239 @@ spec:
               statefulSet:
                 description: RuntimeComponentStatefulSet settings
                 properties:
+                  storage:
+                    description: RuntimeComponentStorage ...
+                    properties:
+                      mountPath:
+                        type: string
+                      size:
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                        type: string
+                      volumeClaimTemplate:
+                        description: PersistentVolumeClaim is a user's request for
+                          and claim to a persistent volume
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema
+                              of this representation of an object. Servers should
+                              convert recognized schemas to the latest internal value,
+                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the
+                              REST resource this object represents. Servers may infer
+                              this from the endpoint the client submits requests to.
+                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          metadata:
+                            description: 'Standard object''s metadata. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            type: object
+                          spec:
+                            description: 'Spec defines the desired characteristics
+                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access
+                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              dataSource:
+                                description: 'This field can be used to specify either:
+                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                  - Beta) * An existing PVC (PersistentVolumeClaim)
+                                  * An existing custom resource/object that implements
+                                  data population (Alpha) In order to use VolumeSnapshot
+                                  object types, the appropriate feature gate must
+                                  be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                  If the provisioner or an external controller can
+                                  support the specified data source, it will create
+                                  a new volume based on the contents of the specified
+                                  data source. If the specified data source is not
+                                  supported, the volume will not be created and the
+                                  failure will be reported as an event. In the future,
+                                  we plan to support more data source types and the
+                                  behavior of the provisioner may change.'
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              resources:
+                                description: 'Resources represents the minimum resources
+                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                              selector:
+                                description: A label query over volumes to consider
+                                  for binding.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by
+                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume
+                                  is required by the claim. Value of Filesystem is
+                                  implied when not included in claim spec.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to
+                                  the PersistentVolume backing this claim.
+                                type: string
+                            type: object
+                          status:
+                            description: 'Status represents the current information/status
+                              of a persistent volume claim. Read-only. More info:
+                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the actual access
+                                  modes the volume backing the PVC has. More info:
+                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              capacity:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: Represents the actual resources of the
+                                  underlying volume.
+                                type: object
+                              conditions:
+                                description: Current Condition of persistent volume
+                                  claim. If underlying persistent volume is being
+                                  resized then the Condition will be set to 'ResizeStarted'.
+                                items:
+                                  description: PersistentVolumeClaimCondition contails
+                                    details about state of pvc
+                                  properties:
+                                    lastProbeTime:
+                                      description: Last time we probed the condition.
+                                      format: date-time
+                                      type: string
+                                    lastTransitionTime:
+                                      description: Last time the condition transitioned
+                                        from one status to another.
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Human-readable message indicating
+                                        details about last transition.
+                                      type: string
+                                    reason:
+                                      description: Unique, this should be a short,
+                                        machine understandable string that gives the
+                                        reason for condition's last transition. If
+                                        it reports "ResizeStarted" that means the
+                                        underlying persistent volume is being resized.
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      description: PersistentVolumeClaimConditionType
+                                        is a valid value of PersistentVolumeClaimCondition.Type
+                                      type: string
+                                  required:
+                                  - status
+                                  - type
+                                  type: object
+                                type: array
+                              phase:
+                                description: Phase represents the current phase of
+                                  PersistentVolumeClaim.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
                   updateStrategy:
                     description: StatefulSetUpdateStrategy indicates the strategy
                       that the StatefulSet controller will use to perform updates.
@@ -3989,229 +4222,6 @@ spec:
                         description: Type indicates the type of the StatefulSetUpdateStrategy.
                           Default is RollingUpdate.
                         type: string
-                    type: object
-                type: object
-              storage:
-                description: RuntimeComponentStorage ...
-                properties:
-                  mountPath:
-                    type: string
-                  size:
-                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                    type: string
-                  volumeClaimTemplate:
-                    description: PersistentVolumeClaim is a user's request for and
-                      claim to a persistent volume
-                    properties:
-                      apiVersion:
-                        description: 'APIVersion defines the versioned schema of this
-                          representation of an object. Servers should convert recognized
-                          schemas to the latest internal value, and may reject unrecognized
-                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                        type: string
-                      kind:
-                        description: 'Kind is a string value representing the REST
-                          resource this object represents. Servers may infer this
-                          from the endpoint the client submits requests to. Cannot
-                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        type: object
-                      spec:
-                        description: 'Spec defines the desired characteristics of
-                          a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          accessModes:
-                            description: 'AccessModes contains the desired access
-                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                            items:
-                              type: string
-                            type: array
-                          dataSource:
-                            description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                              - Beta) * An existing PVC (PersistentVolumeClaim) *
-                              An existing custom resource/object that implements data
-                              population (Alpha) In order to use VolumeSnapshot object
-                              types, the appropriate feature gate must be enabled
-                              (VolumeSnapshotDataSource or AnyVolumeDataSource) If
-                              the provisioner or an external controller can support
-                              the specified data source, it will create a new volume
-                              based on the contents of the specified data source.
-                              If the specified data source is not supported, the volume
-                              will not be created and the failure will be reported
-                              as an event. In the future, we plan to support more
-                              data source types and the behavior of the provisioner
-                              may change.'
-                            properties:
-                              apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified,
-                                  the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
-                                type: string
-                              kind:
-                                description: Kind is the type of resource being referenced
-                                type: string
-                              name:
-                                description: Name is the name of resource being referenced
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                          resources:
-                            description: 'Resources represents the minimum resources
-                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                            type: object
-                          selector:
-                            description: A label query over volumes to consider for
-                              binding.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          storageClassName:
-                            description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                            type: string
-                          volumeMode:
-                            description: volumeMode defines what type of volume is
-                              required by the claim. Value of Filesystem is implied
-                              when not included in claim spec.
-                            type: string
-                          volumeName:
-                            description: VolumeName is the binding reference to the
-                              PersistentVolume backing this claim.
-                            type: string
-                        type: object
-                      status:
-                        description: 'Status represents the current information/status
-                          of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          accessModes:
-                            description: 'AccessModes contains the actual access modes
-                              the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                            items:
-                              type: string
-                            type: array
-                          capacity:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: Represents the actual resources of the underlying
-                              volume.
-                            type: object
-                          conditions:
-                            description: Current Condition of persistent volume claim.
-                              If underlying persistent volume is being resized then
-                              the Condition will be set to 'ResizeStarted'.
-                            items:
-                              description: PersistentVolumeClaimCondition contails
-                                details about state of pvc
-                              properties:
-                                lastProbeTime:
-                                  description: Last time we probed the condition.
-                                  format: date-time
-                                  type: string
-                                lastTransitionTime:
-                                  description: Last time the condition transitioned
-                                    from one status to another.
-                                  format: date-time
-                                  type: string
-                                message:
-                                  description: Human-readable message indicating details
-                                    about last transition.
-                                  type: string
-                                reason:
-                                  description: Unique, this should be a short, machine
-                                    understandable string that gives the reason for
-                                    condition's last transition. If it reports "ResizeStarted"
-                                    that means the underlying persistent volume is
-                                    being resized.
-                                  type: string
-                                status:
-                                  type: string
-                                type:
-                                  description: PersistentVolumeClaimConditionType
-                                    is a valid value of PersistentVolumeClaimCondition.Type
-                                  type: string
-                              required:
-                              - status
-                              - type
-                              type: object
-                            type: array
-                          phase:
-                            description: Phase represents the current phase of PersistentVolumeClaim.
-                            type: string
-                        type: object
                     type: object
                 type: object
               version:

--- a/controllers/runtimecomponent_controller.go
+++ b/controllers/runtimecomponent_controller.go
@@ -324,7 +324,10 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 	}
 
-	if instance.Spec.Storage != nil {
+	if instance.Spec.StatefulSet != nil {
+		l := reqLogger.WithValues("instance.Spec.StatefulSet!!!!!", instance.Spec.StatefulSet)
+		l.Info("")
+
 		// Delete Deployment if exists
 		deploy := &appsv1.Deployment{ObjectMeta: defaultMeta}
 		err = r.DeleteResource(deploy)

--- a/doc/user-guide.adoc
+++ b/doc/user-guide.adoc
@@ -37,9 +37,10 @@ spec:
     type: ClusterIP
     port: 9080
   expose: true
-  storage:
-    size: 2Gi
-    mountPath: "/logs"
+  statefulSet:
+    storage:
+      size: 2Gi
+      mountPath: "/logs"
 ----
 
 == Configuration
@@ -108,9 +109,9 @@ Each `RuntimeComponent` CR must at least specify the `applicationImage` paramete
 | `startupProbe` | A YAML object configuring the link:++https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes++[Kubernetes startup probe] that controls when Kubernetes needs to startup the pod on its first initialization.
 | `volumes` | A YAML object that represents a link:++https://kubernetes.io/docs/concepts/storage/volumes++[pod volume].
 | `volumeMounts` | A YAML object that represents a link:++https://kubernetes.io/docs/concepts/storage/volumes/++[pod volumeMount].
-| `storage.size` | A convenient field to set the size of the persisted storage. Can be overridden by the `storage.volumeClaimTemplate` property.
-| `storage.mountPath` | The directory inside the container where this persisted storage will be bound to.
-| `storage.volumeClaimTemplate` | A YAML object that represents a link:++https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#components++[volumeClaimTemplate] component of a `StatefulSet`.
+| `statefulSet.storage.size` | A convenient field to set the size of the persisted storage. Can be overridden by the `storage.volumeClaimTemplate` property.
+| `statefulSet.storage.mountPath` | The directory inside the container where this persisted storage will be bound to.
+| `statefulSet.storage.volumeClaimTemplate` | A YAML object that represents a link:++https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#components++[volumeClaimTemplate] component of a `StatefulSet`.
 | `monitoring.labels` | Labels to set on link:++https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor++[ServiceMonitor].
 | `monitoring.endpoints` | A YAML snippet representing an array of link:++https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint++[Endpoint] component from ServiceMonitor.
 | `route.annotations` | Annotations to be added to the Route.
@@ -361,7 +362,7 @@ Users also can provide mount points for their application. There are 2 ways to e
 
 With the `RuntimeComponent` CR definition below the operator will create `PersistentVolumeClaim` called `pvc` with the size of `1Gi` and `ReadWriteOnce` access mode.
 
-The operator will also create a volume mount for the `StatefulSet` mounting to `/data` folder. You can use `volumeMounts` field instead of `storage.mountPath` if you require to persist more then one folder.
+The operator will also create a volume mount for the `StatefulSet` mounting to `/data` folder. You can use `volumeMounts` field instead of `statefulSet.storage.mountPath` if you require to persist more then one folder.
 
 [source,yaml]
 ----
@@ -371,16 +372,17 @@ metadata:
   name: my-app
 spec:
   applicationImage: quay.io/my-repo/my-app:1.0
-  storage:
-    size: 1Gi
-    mountPath: "/data"
+  statefulSet:
+    storage:
+      size: 1Gi
+      mountPath: "/data"
 ----
 
 ==== Advanced storage
 
 Runtime Component Operator allows users to provide entire `volumeClaimTemplate` for full control over automatically created `PersistentVolumeClaim`.
 
-It is also possible to create multiple volume mount points for persistent volume using `volumeMounts` field as shown below. You can still use `storage.mountPath` if you require only a single mount point.
+It is also possible to create multiple volume mount points for persistent volume using `volumeMounts` field as shown below. You can still use `statefulSet.storage.mountPath` if you require only a single mount point.
 
 [source,yaml]
 ----
@@ -397,17 +399,18 @@ spec:
   - name: pvc
     mountPath: /data_2
     subPath: data_2
-  storage:
-    volumeClaimTemplate:
-      metadata:
-        name: pvc
-      spec:
-        accessModes:
-        - "ReadWriteMany"
-        storageClassName: 'glusterfs'
-        resources:
-          requests:
-            storage: 1Gi
+  statefulSet:
+    storage:
+      volumeClaimTemplate:
+        metadata:
+          name: pvc
+        spec:
+          accessModes:
+          - "ReadWriteMany"
+          storageClassName: 'glusterfs'
+          resources:
+            requests:
+              storage: 1Gi
 ----
 
 === Service binding

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -520,53 +520,54 @@ func CustomizeConsumedServices(podSpec *corev1.PodSpec, ba common.BaseComponent)
 
 // CustomizePersistence ...
 func CustomizePersistence(statefulSet *appsv1.StatefulSet, ba common.BaseComponent) {
-	obj := ba.(metav1.Object)
-	if len(statefulSet.Spec.VolumeClaimTemplates) == 0 {
-		var pvc *corev1.PersistentVolumeClaim
-		if ba.GetStorage().GetVolumeClaimTemplate() != nil {
-			pvc = ba.GetStorage().GetVolumeClaimTemplate()
-		} else {
-			pvc = &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pvc",
-					Namespace: obj.GetNamespace(),
-					Labels:    ba.GetLabels(),
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse(ba.GetStorage().GetSize()),
+	obj, ss := ba.(metav1.Object), ba.GetStatefulSet()
+	if ss.GetStorage() != nil {
+		if len(statefulSet.Spec.VolumeClaimTemplates) == 0 {
+			var pvc *corev1.PersistentVolumeClaim
+			if ss.GetStorage().GetVolumeClaimTemplate() != nil {
+				pvc = ss.GetStorage().GetVolumeClaimTemplate()
+			} else {
+				pvc = &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc",
+						Namespace: obj.GetNamespace(),
+						Labels:    ba.GetLabels(),
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse(ss.GetStorage().GetSize()),
+							},
+						},
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
 						},
 					},
-					AccessModes: []corev1.PersistentVolumeAccessMode{
-						corev1.ReadWriteOnce,
-					},
-				},
+				}
+				pvc.Annotations = MergeMaps(pvc.Annotations, ba.GetAnnotations())
 			}
-			pvc.Annotations = MergeMaps(pvc.Annotations, ba.GetAnnotations())
-		}
-		statefulSet.Spec.VolumeClaimTemplates = append(statefulSet.Spec.VolumeClaimTemplates, *pvc)
-	}
-
-	appContainer := GetAppContainer(statefulSet.Spec.Template.Spec.Containers)
-
-	if ba.GetStorage().GetMountPath() != "" {
-		found := false
-		for _, v := range appContainer.VolumeMounts {
-			if v.Name == statefulSet.Spec.VolumeClaimTemplates[0].Name {
-				found = true
-			}
+			statefulSet.Spec.VolumeClaimTemplates = append(statefulSet.Spec.VolumeClaimTemplates, *pvc)
 		}
 
-		if !found {
-			vm := corev1.VolumeMount{
-				Name:      statefulSet.Spec.VolumeClaimTemplates[0].Name,
-				MountPath: ba.GetStorage().GetMountPath(),
+		appContainer := GetAppContainer(statefulSet.Spec.Template.Spec.Containers)
+
+		if ss.GetStorage().GetMountPath() != "" {
+			found := false
+			for _, v := range appContainer.VolumeMounts {
+				if v.Name == statefulSet.Spec.VolumeClaimTemplates[0].Name {
+					found = true
+				}
 			}
-			appContainer.VolumeMounts = append(appContainer.VolumeMounts, vm)
+
+			if !found {
+				vm := corev1.VolumeMount{
+					Name:      statefulSet.Spec.VolumeClaimTemplates[0].Name,
+					MountPath: ss.GetStorage().GetMountPath(),
+				}
+				appContainer.VolumeMounts = append(appContainer.VolumeMounts, vm)
+			}
 		}
 	}
-
 }
 
 // CustomizeServiceAccount ...
@@ -680,7 +681,7 @@ func CustomizeHPA(hpa *autoscalingv1.HorizontalPodAutoscaler, ba common.BaseComp
 	hpa.Spec.ScaleTargetRef.Name = obj.GetName()
 	hpa.Spec.ScaleTargetRef.APIVersion = "apps/v1"
 
-	if ba.GetStorage() != nil {
+	if ba.GetStatefulSet() != nil && ba.GetStatefulSet().GetStorage() != nil {
 		hpa.Spec.ScaleTargetRef.Kind = "StatefulSet"
 	} else {
 		hpa.Spec.ScaleTargetRef.Kind = "Deployment"
@@ -690,13 +691,14 @@ func CustomizeHPA(hpa *autoscalingv1.HorizontalPodAutoscaler, ba common.BaseComp
 // Validate if the BaseComponent is valid
 func Validate(ba common.BaseComponent) (bool, error) {
 	// Storage validation
-	if ba.GetStorage() != nil {
-		if ba.GetStorage().GetVolumeClaimTemplate() == nil {
-			if ba.GetStorage().GetSize() == "" {
+	ss := ba.GetStatefulSet()
+	if ss != nil && ss.GetStorage() != nil {
+		if ss.GetStorage().GetVolumeClaimTemplate() == nil {
+			if ss.GetStorage().GetSize() == "" {
 				return false, fmt.Errorf("validation failed: " + requiredFieldMessage("spec.storage.size"))
 			}
-			if _, err := resource.ParseQuantity(ba.GetStorage().GetSize()); err != nil {
-				return false, fmt.Errorf("validation failed: cannot parse '%v': %v", ba.GetStorage().GetSize(), err)
+			if _, err := resource.ParseQuantity(ss.GetStorage().GetSize()); err != nil {
+				return false, fmt.Errorf("validation failed: cannot parse '%v': %v", ss.GetStorage().GetSize(), err)
 			}
 		}
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -346,7 +346,8 @@ func TestCustomizePersistence(t *testing.T) {
 	logger := zap.New()
 	logf.SetLogger(logger)
 
-	spec := appstacksv1beta1.RuntimeComponentSpec{Storage: &storage}
+	runtimeStatefulSet := &appstacksv1beta1.RuntimeComponentStatefulSet{Storage: &storage}
+	spec := appstacksv1beta1.RuntimeComponentSpec{StatefulSet: runtimeStatefulSet}
 	statefulSet, runtime := &appsv1.StatefulSet{}, createRuntimeComponent(name, namespace, spec)
 	statefulSet.Spec.Template.Spec.Containers = []corev1.Container{{}}
 	statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}
@@ -357,7 +358,8 @@ func TestCustomizePersistence(t *testing.T) {
 
 	//reset
 	storageNilVCT := appstacksv1beta1.RuntimeComponentStorage{Size: "10Mi", MountPath: "/mnt/data", VolumeClaimTemplate: nil}
-	spec = appstacksv1beta1.RuntimeComponentSpec{Storage: &storageNilVCT}
+	runtimeStatefulSet = &appstacksv1beta1.RuntimeComponentStatefulSet{Storage: &storageNilVCT}
+	spec = appstacksv1beta1.RuntimeComponentSpec{StatefulSet: runtimeStatefulSet}
 	statefulSet, runtime = &appsv1.StatefulSet{}, createRuntimeComponent(name, namespace, spec)
 
 	statefulSet.Spec.Template.Spec.Containers = []corev1.Container{{}}
@@ -473,7 +475,8 @@ func TestCustomizeHPA(t *testing.T) {
 	CustomizeHPA(hpa, runtime)
 	nilSTRKind := hpa.Spec.ScaleTargetRef.Kind
 
-	spec = appstacksv1beta1.RuntimeComponentSpec{Autoscaling: autoscaling, Storage: &storage}
+	runtimeStatefulSet := &appstacksv1beta1.RuntimeComponentStatefulSet{Storage: &storage}
+	spec = appstacksv1beta1.RuntimeComponentSpec{Autoscaling: autoscaling, StatefulSet: runtimeStatefulSet}
 	runtime = createRuntimeComponent(name, namespace, spec)
 	CustomizeHPA(hpa, runtime)
 	STRKind := hpa.Spec.ScaleTargetRef.Kind


### PR DESCRIPTION
**What this PR does / why we need it?**:
- To create statefulset without requiring PVC for each instance
- storage field is moved under statefulSet field

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [x] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #195 
