### PR TITLE
UpdateStrategy to RollingUpdate when nil

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -48,14 +48,11 @@ func CustomizeDeployment(deploy *appsv1.Deployment, ba common.BaseComponent) {
 	}
 
 	dp := ba.GetDeployment()
-	if dp != nil {
-		if dp.GetDeploymentUpdateStrategy() != nil {
-			deploy.Spec.Strategy = *dp.GetDeploymentUpdateStrategy()
-		} else {
-			deploy.Spec.Strategy = appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
-		}
+	if dp != nil && dp.GetDeploymentUpdateStrategy() != nil {
+		deploy.Spec.Strategy = *dp.GetDeploymentUpdateStrategy()
+	} else {
+		deploy.Spec.Strategy = appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
 	}
-
 }
 
 // CustomizeStatefulSet ...

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -48,8 +48,12 @@ func CustomizeDeployment(deploy *appsv1.Deployment, ba common.BaseComponent) {
 	}
 
 	dp := ba.GetDeployment()
-	if dp != nil && dp.GetDeploymentUpdateStrategy() != nil {
-		deploy.Spec.Strategy = *dp.GetDeploymentUpdateStrategy()
+	if dp != nil {
+		if dp.GetDeploymentUpdateStrategy() != nil {
+			deploy.Spec.Strategy = *dp.GetDeploymentUpdateStrategy()
+		} else {
+			deploy.Spec.Strategy = appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType}
+		}
 	}
 
 }
@@ -73,8 +77,12 @@ func CustomizeStatefulSet(statefulSet *appsv1.StatefulSet, ba common.BaseCompone
 	}
 
 	ss := ba.GetStatefulSet()
-	if ss != nil && ss.GetStatefulSetUpdateStrategy() != nil {
-		statefulSet.Spec.UpdateStrategy = *ss.GetStatefulSetUpdateStrategy()
+	if ss != nil {
+		if ss.GetStatefulSetUpdateStrategy() != nil {
+			statefulSet.Spec.UpdateStrategy = *ss.GetStatefulSetUpdateStrategy()
+		} else {
+			statefulSet.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType}
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it?**:
- Deployment and StatefulSet update strategy should fall back to RollingUpdate when it it set to nil.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #208 
