### PR TITLE
Issue OLO#236: TLS secret timing issue fix

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=runtime-component
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.6.1+git
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: runtime-component
   operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.6.1+git
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1


### PR DESCRIPTION
**What this PR does / why we need it?**:
- There is a timing issue with TLS secret creation. TLS secret is required to pull image from OSCP image registry and it is often not created when the operator tries to pull the image.
- TLS secret will now be created before creating deployment/statefulset

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
