### PR TITLE
Add test for conflicting annotations

### DIFF
--- a/bundle/tests/scorecard/kuttl-disabled/annotations/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl-disabled/annotations/00-assert.yaml
@@ -5,12 +5,14 @@ metadata:
   annotations:
     bar2: foo2
     foo1: bar1  
+    conflict: deployment
 spec:
   template:
     metadata:
       annotations:
         bar2: foo2
         foo1: bar1
+        conflict: deployment
 status:
   readyReplicas: 1
 ---
@@ -20,6 +22,7 @@ metadata:
   name: rc-deployment-annotations
   annotations:
     foo1: bar1
+    conflict: component
 ---
 apiVersion: v1
 kind: Pod
@@ -27,3 +30,4 @@ metadata:
   annotations:
     bar2: foo2
     foo1: bar1
+    conflict: deployment

--- a/bundle/tests/scorecard/kuttl-disabled/annotations/00-rc-deployment.yaml
+++ b/bundle/tests/scorecard/kuttl-disabled/annotations/00-rc-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: rc-deployment-annotations
   annotations:
     foo1: bar1
+    conflict: component
 spec:
   # Add fields here
   applicationImage: 'k8s.gcr.io/pause:2.0'
@@ -11,4 +12,5 @@ spec:
   deployment:
     annotations:
       bar2: foo2
+      conflict: deployment
 

--- a/bundle/tests/scorecard/kuttl-disabled/annotations/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl-disabled/annotations/01-assert.yaml
@@ -5,12 +5,14 @@ metadata:
   annotations:
     bar2: foo2
     foo1: bar1  
+    conflict: statefulSet
 spec:
   template:
     metadata:
       annotations:
         bar2: foo2
         foo1: bar1
+        conflict: statefulSet
 status:
   readyReplicas: 1
 ---
@@ -27,3 +29,4 @@ metadata:
   annotations:
     bar2: foo2
     foo1: bar1
+    conflict: statefulSet

--- a/bundle/tests/scorecard/kuttl-disabled/annotations/01-rc-statefulset.yaml
+++ b/bundle/tests/scorecard/kuttl-disabled/annotations/01-rc-statefulset.yaml
@@ -11,4 +11,4 @@ spec:
   statefulSet:
     annotations:
       bar2: foo2
-
+      conflict: statefulSet


### PR DESCRIPTION
This is a second PR to address issues from issues #213.
Currently, annotations are not removed from the resources when they are removed from the spec, as the operator can't tell if the annotations were added by itself or by openshift, and so doesn't know which annotations to remove.
So this PR is just adding the extra requested tests from the comment in PR https://github.com/application-stacks/runtime-component-operator/pull/211#pullrequestreview-780449333
