### PR TITLE
Fix invalid test tag

### DIFF
--- a/scripts/e2e-release.sh
+++ b/scripts/e2e-release.sh
@@ -59,10 +59,11 @@ main() {
 
 run_e2e() {
   local tag="${1}"
+  local release_tag="${tag//\./}"
   "${script_dir}/e2e.sh" -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" \
                          --cluster-url "${CLUSTER_URL}" --cluster-token "${CLUSTER_TOKEN}" \
                          --registry-name "${REGISTRY_NAME}" --registry-namespace "${REGISTRY_NAMESPACE}" \
-                         --test-tag "${tag}-${TEST_TAG}" --release "${tag}"
+                         --test-tag "${release_tag}-${TEST_TAG}" --release "${tag}"
 }
 
 test_releases() {


### PR DESCRIPTION
Remove the '.' from the tag name as dots are invalid in resource names.
```
The ProjectRequest "runtime-operator-test-v0.8.0-rc2-503" is invalid:
metadata.name: Invalid value: "runtime-operator-test-v0.8.0-rc2-503": a
DNS-1123 label must consist of lower case alphanumeric characters or
'-', and must start and end with an alphanumeric character (e.g.
'my-name',  or '123-abc', regex used for validation is
'[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```

**What this PR does / why we need it?**:

- 
- 

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
