### PR TITLE
Remove travis branch check from push for operator image

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -84,12 +84,8 @@ build_release() {
 }
 
 push_release() {
-  if [[ "${TRAVIS}" = "true" && "${TRAVIS_PULL_REQUEST}" = "false" && "${TRAVIS_BRANCH}" = "master" ]]; then
-    echo "****** Pushing image: ${full_image}"
-    docker push "${full_image}"
-  else
-    echo "****** Skipping push for branch ${TRAVIS_BRANCH}"
-  fi
+  echo "****** Pushing image: ${full_image}"
+  docker push "${full_image}"
 }
 
 parse_args() {


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Operator image not being pushed because of Travis branch check. Remove check entirely to remove dependency on Travis build environment from build scripts.
- 

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
