### PR TITLE
Allow insecureEdgeTerminationPolicy set to redirect on passthrough

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -126,7 +126,11 @@ func CustomizeRoute(route *routev1.Route, ba common.BaseComponent, key string, c
 				route.Spec.TLS.CACertificate = ""
 				route.Spec.TLS.Key = ""
 				route.Spec.TLS.DestinationCACertificate = ""
-				route.Spec.TLS.InsecureEdgeTerminationPolicy = ""
+				if *rt.GetInsecureEdgeTerminationPolicy() == routev1.InsecureEdgeTerminationPolicyRedirect {
+					route.Spec.TLS.InsecureEdgeTerminationPolicy = *rt.GetInsecureEdgeTerminationPolicy()
+				} else {
+					route.Spec.TLS.InsecureEdgeTerminationPolicy = ""
+				}
 			} else if route.Spec.TLS.Termination == routev1.TLSTerminationEdge {
 				route.Spec.TLS.Certificate = crt
 				route.Spec.TLS.CACertificate = ca

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -126,10 +126,8 @@ func CustomizeRoute(route *routev1.Route, ba common.BaseComponent, key string, c
 				route.Spec.TLS.CACertificate = ""
 				route.Spec.TLS.Key = ""
 				route.Spec.TLS.DestinationCACertificate = ""
-				if *rt.GetInsecureEdgeTerminationPolicy() == routev1.InsecureEdgeTerminationPolicyRedirect {
+				if rt.GetInsecureEdgeTerminationPolicy() != nil {
 					route.Spec.TLS.InsecureEdgeTerminationPolicy = *rt.GetInsecureEdgeTerminationPolicy()
-				} else {
-					route.Spec.TLS.InsecureEdgeTerminationPolicy = ""
 				}
 			} else if route.Spec.TLS.Termination == routev1.TLSTerminationEdge {
 				route.Spec.TLS.Certificate = crt


### PR DESCRIPTION
…n Passthrough

Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>

**What this PR does / why we need it?**:

- If TLS termination is set to Passthrough we need to also set InsecureEdgeTerminationPolicy as Redirect is a possible option

