### PR TITLE
Add kustomization patch to add description for service binding secret

### DIFF
--- a/bundle/manifests/runtime-component.clusterserviceversion.yaml
+++ b/bundle/manifests/runtime-component.clusterserviceversion.yaml
@@ -321,6 +321,11 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: Service Binding Secret
+        displayName: Secret
+        path: binding.name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
       version: v1beta2
     - description: Day-2 operation to execute on an instance of runtime component
       displayName: RuntimeOperation

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -6,6 +6,13 @@ resources:
 - ../samples
 - ../scorecard
 
+patches:
+- path: serviceBindingPatch.yaml
+  target:
+    kind: ClusterServiceVersion
+    name: runtime-component.v0.0.0
+    namespace: placeholder
+
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.

--- a/config/manifests/serviceBindingPatch.yaml
+++ b/config/manifests/serviceBindingPatch.yaml
@@ -1,0 +1,10 @@
+- op: add
+  # the '-' means add a new entry at the end of the list
+  path: /spec/customresourcedefinitions/owned/0/statusDescriptors/-
+  value:
+    description: Service Binding Secret
+    displayName: Secret
+    path: binding.name
+    x-descriptors:
+    - urn:alm:descriptor:io.kubernetes:Secret
+


### PR DESCRIPTION
This means that the open shift UI for a RuntimeComponent will render and link to the service binding secret

This address issue #289 