### PR TITLE
Change createdAt date format for better rendering in UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 CREATEDAT ?= AUTO
 
 ifeq ($(CREATEDAT), AUTO)
-CREATEDAT := $(shell date +%y-%m-%dT%TZ)
+CREATEDAT := $(shell date +%Y-%m-%dT%TZ)
 endif
 
 # Default catalog image tag


### PR DESCRIPTION
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>

**What this PR does / why we need it?**:

- Changes the createdAt format to yyyy-mm-ddTTimeZ for better rendering in OperatorHub UI