### PR TITLE
Strip the manager binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY common/ common/
 COPY utils/ utils/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$GO_ARCH GO111MODULE=on go build -mod vendor -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$GO_ARCH GO111MODULE=on go build -ldflags="-s -w" -mod vendor -a -o manager main.go
 
 
 #Build final image


### PR DESCRIPTION
Removes the symbol table which saves aprox 10mb from the image
This means attaching a debugger won't be useful, but that is
unlikely to be useful.
This is also recommended by the cloudpak playbook