### PR TITLE
fix: edits resource limit for runtime component manager operator container from 256Mi to 512Mi (#359)

### DIFF
--- a/bundle/manifests/runtime-component.clusterserviceversion.yaml
+++ b/bundle/manifests/runtime-component.clusterserviceversion.yaml
@@ -437,7 +437,7 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 256Mi
+                    memory: 512Mi
                   requests:
                     cpu: 100m
                     memory: 64Mi


### PR DESCRIPTION
**What this PR does / why we need it?**:

This PR changes resource memory limit for rco controller manager from 256Mi to 512Mi
Because on Openshift, recent rco controller runs into OOMKill (0.8.0, 0.8.1 tested)

**Does this PR introduce a user-facing change?**
No

**Which issue(s) this PR fixes**:

Fixes #359 
