### PR TITLE
Set readOnlyRootFilesystem to false by default

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1102,8 +1102,9 @@ func getSecurityContext(ba common.BaseComponent) *corev1.SecurityContext {
 		Capabilities: &corev1.Capabilities{
 			Drop: cap,
 		},
-		Privileged:   &valFalse,
-		RunAsNonRoot: &valTrue,
+		Privileged:             &valFalse,
+		ReadOnlyRootFilesystem: &valFalse,
+		RunAsNonRoot:           &valTrue,
 	}
 
 	// Customize security context
@@ -1116,6 +1117,9 @@ func getSecurityContext(ba common.BaseComponent) *corev1.SecurityContext {
 		}
 		if baSecurityContext.Privileged == nil {
 			baSecurityContext.Privileged = secContext.Privileged
+		}
+		if baSecurityContext.ReadOnlyRootFilesystem == nil {
+			baSecurityContext.ReadOnlyRootFilesystem = secContext.ReadOnlyRootFilesystem
 		}
 		if baSecurityContext.RunAsNonRoot == nil {
 			baSecurityContext.RunAsNonRoot = secContext.RunAsNonRoot


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Linter check requires readOnlyRootFilesystem to be set 

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
