### PR TITLE
Update microprofile health probe defaults

### DIFF
--- a/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
@@ -14,34 +14,34 @@ spec:
     spec:
       containers:
       - livenessProbe:
-          failureThreshold: 3
           httpGet:
             path: /health/live
             port: 9443
             scheme: HTTPS
           initialDelaySeconds: 60
           periodSeconds: 10
+          timeoutSeconds: 2
           successThreshold: 1
-          timeoutSeconds: 3
-        readinessProbe:
           failureThreshold: 3
+        readinessProbe:
           httpGet:
             path: /health/ready
             port: 9443
             scheme: HTTPS
-          initialDelaySeconds: 30
+          initialDelaySeconds: 10
           periodSeconds: 10
+          timeoutSeconds: 2
           successThreshold: 1
-          timeoutSeconds: 3
+          failureThreshold: 10
         startupProbe:
-          failureThreshold: 3
           httpGet:
             path: /health/started
             port: 9443
             scheme: HTTPS
           periodSeconds: 10
+          timeoutSeconds: 2
           successThreshold: 1
-          timeoutSeconds: 1
+          failureThreshold: 20
 status:
   observedGeneration: 4
   readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
@@ -14,14 +14,14 @@ spec:
     spec:
       containers:
       - startupProbe:
-          failureThreshold: 3
           httpGet:
             path: /health/started
             port: 9443
             scheme: HTTPS
           periodSeconds: 10
+          timeoutSeconds: 2
           successThreshold: 1
-          timeoutSeconds: 1
+          failureThreshold: 20
 status:
   observedGeneration: 5
   readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/04-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/04-errors.yaml
@@ -12,7 +12,7 @@ spec:
         - livenessProbe:
             failureThreshold: 3
           readinessProbe:
-            failureThreshold: 3
+            failureThreshold: 10
 status:
   observedGeneration: 5
   replicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
@@ -14,15 +14,16 @@ spec:
     spec:
       containers:
       - startupProbe:
-          failureThreshold: 3
           httpGet:
             path: /health/started
             port: 9443
             scheme: HTTPS
           initialDelaySeconds: 3
           periodSeconds: 10
+          timeoutSeconds: 2
           successThreshold: 1
-          timeoutSeconds: 1
+          failureThreshold: 20
+
 status:
   observedGeneration: 6
   readyReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/05-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/05-errors.yaml
@@ -12,7 +12,7 @@ spec:
         - livenessProbe:
             failureThreshold: 3
           readinessProbe:
-            failureThreshold: 3
+            failureThreshold: 10
 status:
   observedGeneration: 6
   replicas: 1

--- a/common/common.go
+++ b/common/common.go
@@ -15,6 +15,9 @@ func GetDefaultMicroProfileStartupProbe(ba BaseComponent) *corev1.Probe {
 				Scheme: "HTTPS",
 			},
 		},
+		PeriodSeconds:    10,
+		TimeoutSeconds:   2,
+		FailureThreshold: 20,
 	}
 }
 
@@ -28,10 +31,10 @@ func GetDefaultMicroProfileReadinessProbe(ba BaseComponent) *corev1.Probe {
 				Scheme: "HTTPS",
 			},
 		},
-		InitialDelaySeconds: 30,
+		InitialDelaySeconds: 10,
 		PeriodSeconds:       10,
-		TimeoutSeconds:      3,
-		FailureThreshold:    3,
+		TimeoutSeconds:      2,
+		FailureThreshold:    10,
 	}
 }
 
@@ -47,7 +50,7 @@ func GetDefaultMicroProfileLivenessProbe(ba BaseComponent) *corev1.Probe {
 		},
 		InitialDelaySeconds: 60,
 		PeriodSeconds:       10,
-		TimeoutSeconds:      3,
+		TimeoutSeconds:      2,
 		FailureThreshold:    3,
 	}
 }


### PR DESCRIPTION
readiness:
  InitialDelaySeconds: 10
  PeriodSeconds:       10
  TimeoutSeconds:      2
  FailureThreshold:    10

liveness:
  InitialDelaySeconds: 60
  PeriodSeconds:       10
  TimeoutSeconds:      2
  FailureThreshold:    3

startup:
  PeriodSeconds:       10
  TimeoutSeconds:      2
  FailureThreshold:    20

**What this PR does / why we need it?**:

- 
- 

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
