### PR TITLE
If targetport not set default it to the port value within the CR

### DIFF
--- a/api/v1beta2/runtimecomponent_types.go
+++ b/api/v1beta2/runtimecomponent_types.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -807,6 +808,13 @@ func (cr *RuntimeComponent) Initialize() {
 		cr.Spec.Service.Port = 8080
 	}
 
+	// If TargetPorts on Serviceports are not set, default them to the Port value in the CR
+	numOfAdditionalPorts := len(cr.GetService().GetPorts())
+	for i := 0; i < numOfAdditionalPorts; i++ {
+		if cr.Spec.Service.Ports[i].TargetPort.String() == "0" {
+			cr.Spec.Service.Ports[i].TargetPort = intstr.FromInt(int(cr.Spec.Service.Ports[i].Port))
+		}
+	}
 }
 
 // GetLabels returns set of labels to be added to all resources

--- a/controllers/runtimecomponent_controller.go
+++ b/controllers/runtimecomponent_controller.go
@@ -51,7 +51,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -133,7 +132,6 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// initialize the RuntimeComponent instance
 	instance.Initialize()
-
 	_, err = appstacksutils.Validate(instance)
 	// If there's any validation error, don't bother with requeuing
 	if err != nil {
@@ -147,13 +145,7 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// it is not possible to override converted annotations.
 		instance.Annotations = appstacksutils.MergeMaps(instance.Annotations, appstacksutils.GetOpenShiftAnnotations(instance))
 	}
-	// If TargetPorts on Serviceports are not set, default them to the Port value in the CR instance
-	numOfAdditionalPorts := len(instance.GetService().GetPorts())
-	for i := 0; i < numOfAdditionalPorts; i++ {
-		if instance.Spec.Service.Ports[i].TargetPort.String() == "0" {
-			instance.Spec.Service.Ports[i].TargetPort = intstr.FromInt(int(instance.Spec.Service.Ports[i].Port))
-		}
-	}
+
 	err = r.GetClient().Update(context.TODO(), instance)
 	if err != nil {
 		reqLogger.Error(err, "Error updating RuntimeComponent")


### PR DESCRIPTION
Signed-off-by: Jason Yong <jason_yong@uk.ibm.com>

**What this PR does / why we need it?**:

- If the Targetports are not set within a ServicePort then the CR sets and displays them as 0 even though the service correctly sets them to the Port value. This PR ensures that the CR value for Targetports match that of the Service created.

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #346
