### PR TITLE
Update env var for operator namespace

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1190,11 +1190,11 @@ func GetWatchNamespace() (string, error) {
 
 // GetOperatorNamespace returns the Namespace the operator installed in
 func GetOperatorNamespace() (string, error) {
-	var podNamespaceEnvVar = "POD_NAMESPACE"
+	var operatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 
-	ns, found := os.LookupEnv(podNamespaceEnvVar)
+	ns, found := os.LookupEnv(operatorNamespaceEnvVar)
 	if !found {
-		return "", fmt.Errorf("%s must be set", podNamespaceEnvVar)
+		return "", fmt.Errorf("%s must be set", operatorNamespaceEnvVar)
 	}
 	return ns, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it?**:

As the result of a bug, the operator is unable to create the "runtime-component-operator" ConfigMap in any other namespace other than the first namespace listed in the watch namepace(s) list. If all namespaces are being watched, then no ConfigMap would be created.    Update the code to read the namespace the operator is running and use that namespace to check for and create the runtime-component-operator ConfigMap if necessary. 

- 
- 

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
