### PR TITLE
Fix memory limit in manager.yaml

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 64Mi


### PR DESCRIPTION
This is to match the previous change in the CSV, to prevent it
being lost
