### PR TITLE
Create operator config map in main

### DIFF
--- a/controllers/runtimecomponent_controller.go
+++ b/controllers/runtimecomponent_controller.go
@@ -55,6 +55,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	OperatorName = "runtime-component-operator"
+)
+
 // RuntimeComponentReconciler reconciles a RuntimeComponent object
 type RuntimeComponentReconciler struct {
 	appstacksutils.ReconcilerBase
@@ -97,11 +101,11 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		ns = r.watchNamespaces[0]
 	}
 
-	configMap, err := r.GetOpConfigMap("runtime-component-operator", ns)
+	configMap, err := r.GetOpConfigMap(OperatorName, ns)
 	if err != nil {
 		reqLogger.Info("Failed to find runtime-component-operator config map")
 		common.Config = common.DefaultOpConfig()
-		configMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "runtime-component-operator", Namespace: ns}}
+		configMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: OperatorName, Namespace: ns}}
 		configMap.Data = common.Config
 	} else {
 		common.Config.LoadFromConfigMap(configMap)

--- a/main.go
+++ b/main.go
@@ -117,11 +117,14 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
+	utils.CreateConfigMap(controllers.OperatorName)
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+
 }
 
 // getWatchNamespace returns the Namespace the operator should be watching for changes


### PR DESCRIPTION
This is to ensure that the config map exists before the
first runtime component is created

This address issue #386 

