### PR TITLE
Make getSecurityContext public

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1395,7 +1395,7 @@ func ServiceAccountPullSecretExists(ba common.BaseComponent, client client.Clien
 }
 
 // Get security context from CR and apply customization to default settings
-func getSecurityContext(ba common.BaseComponent) *corev1.SecurityContext {
+func GetSecurityContext(ba common.BaseComponent) *corev1.SecurityContext {
 	baSecurityContext := ba.GetSecurityContext()
 
 	valFalse := false


### PR DESCRIPTION
**What this PR does / why we need it?**:

Makes the function getSecurityContext in util.go public, so that other projects  can use this utility function.

**Does this PR introduce a user-facing change?**

No. 

- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:

No current open issue for this item.  This is to support add support for https://github.com/WASdev/websphere-liberty-operator/issues/282
