### PR TITLE
Expose application ready message as const variable

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -89,6 +89,9 @@ const (
 	StatusConditionTypeResourcesReady StatusConditionType = "ResourcesReady"
 	StatusConditionTypeReady          StatusConditionType = "Ready"
 
+	// Status Condition Type Messages
+	StatusConditionTypeReadyMessage string = "Application is reconciled and resources are ready."
+
 	// Status Endpoint Scopes
 	StatusEndpointScopeExternal StatusEndpointScope = "External"
 	StatusEndpointScopeInternal StatusEndpointScope = "Internal"

--- a/utils/status.go
+++ b/utils/status.go
@@ -52,7 +52,7 @@ func (r *ReconcilerBase) CheckApplicationStatus(ba common.BaseComponent) corev1.
 			reason = "ResourcesNotReady"
 		} else {
 			status = corev1.ConditionTrue
-			msg = "Application is reconciled and resources are ready."
+			msg = common.StatusConditionTypeReadyMessage
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Creates a const string variable that can be referred to by https://github.com/WASdev/websphere-liberty-operator/issues/345 instead of hard coding the string for the fix.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
