### PR TITLE
Fix ready and reconcile status during upgrade

### DIFF
--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -193,6 +193,19 @@ func (r *ReconcilerBase) ManageError(issue error, conditionType common.StatusCon
 	if conditionType != common.StatusConditionTypeResourcesReady {
 		//Check Application status (reconciliation & resource status & endpoint status)
 		r.CheckApplicationStatus(ba)
+	} else {
+		// If the new condition type is ResourcesReady (false), make sure the existing
+		// conditions for Ready and Reconciled are set to false
+		readyNewCondition := s.NewCondition(common.StatusConditionTypeReady)
+		readyNewCondition.SetStatus(corev1.ConditionFalse)
+		readyNewCondition.SetMessage("Resources not ready.")
+		readyNewCondition.SetReason("")
+		s.SetCondition(readyNewCondition)
+		reconciledNewCondition := s.NewCondition(common.StatusConditionTypeReconciled)
+		reconciledNewCondition.SetStatus(corev1.ConditionFalse)
+		reconciledNewCondition.SetMessage("Resources not ready.")
+		reconciledNewCondition.SetReason("")
+		s.SetCondition(reconciledNewCondition)
 	}
 
 	err := r.UpdateStatus(obj)


### PR DESCRIPTION
**What this PR does / why we need it?**:

When upgrading, and the Reconciled and Ready field are already set (possibly to true), and the ResourcesReady
condition becomes false again, set the Ready and Reconciled fields to reflect the overall new state. 

**Does this PR introduce a user-facing change?**
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:

[Fixes #](https://github.com/WASdev/websphere-liberty-operator/issues/326#issuecomment-1323921545)
