### PR TITLE
Use image sha for sample image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: bundle
 bundle: manifests setup kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	scripts/update-sample.sh
 	sed -i.bak "s,IMAGE,${IMG},g;s,CREATEDAT,${CREATEDAT},g" config/manifests/patches/csvAnnotations.yaml
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)

--- a/bundle/manifests/runtime-component.clusterserviceversion.yaml
+++ b/bundle/manifests/runtime-component.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
             "name": "runtimecomponent-sample"
           },
           "spec": {
-            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started",
+            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:60ca13dd15d5dd583a594436d3568fc69fc7a58081dc40885dc4d2b16a6e4c69",
             "expose": true,
             "replicas": 1,
             "service": {
@@ -67,7 +67,7 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: applicationstacks/operator:daily
-    createdAt: "2023-03-01T12:55:30Z"
+    createdAt: "2023-03-09T10:51:34Z"
     description: Deploys any runtime component with dynamic and auto-tuning configuration
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/samples/rc.app.stacks_v1_runtimecomponent.yaml
+++ b/config/samples/rc.app.stacks_v1_runtimecomponent.yaml
@@ -4,7 +4,7 @@ metadata:
   name: runtimecomponent-sample
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:60ca13dd15d5dd583a594436d3568fc69fc7a58081dc40885dc4d2b16a6e4c69
   expose: true
   replicas: 1
   service:

--- a/scripts/update-sample.sh
+++ b/scripts/update-sample.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script fetches the sha256 for the latest version of the open liberty getting started container
+# image, and then edits the sample deployment and the csv for the operator, and inserts the tag
+
+if ! skopeo -v ; then
+  echo "Skopeo is not installed. Sample sha will not be updated"
+  exit
+fi
+
+echo "Editing sample tag"
+SHA=$(skopeo inspect docker://icr.io/appcafe/open-liberty/samples/getting-started:latest | jq '.Digest'| sed -e 's/"//g')
+if [ -z $SHA ]
+then
+  echo "Couldn't find latest SHA for sample image"
+  exit
+fi
+
+echo "sha is $SHA"
+
+files=" 
+config/samples/rc.app.stacks_v1_runtimecomponent.yaml
+"
+
+for file in $files 
+do
+  sed -i.bak "s,getting-started@sha256:[a-zA-Z0-9]*,getting-started@$SHA," $file
+  rm $file.bak
+done
+


### PR DESCRIPTION
The RedHat certification requires that images are referenced by sha. Add a sha for the sample image, and also add a script to update the sha when 'make bundle' is run

This is the RCO portion of https://github.com/WASdev/websphere-liberty-operator/issues/214