### PR TITLE
Handle k8s resource conflict due to same CR names

### DIFF
--- a/controllers/runtimecomponent_controller.go
+++ b/controllers/runtimecomponent_controller.go
@@ -234,6 +234,13 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		reqLogger.V(1).Info(fmt.Sprintf("%s is not supported on the cluster", servingv1.SchemeGroupVersion.String()))
 	}
 
+	// Check if there is an existing Deployment, Statefulset or Knative service by this name
+	// not managed by this operator
+	err = appstacksutils.CheckForExistingDeployments("RuntimeComponent", instance.Name, instance.Namespace, r.GetClient(), req, isKnativeSupported)
+	if err != nil {
+		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+	}
+
 	if instance.Spec.CreateKnativeService != nil && *instance.Spec.CreateKnativeService {
 		// Clean up non-Knative resources
 		resources := []client.Object{

--- a/controllers/runtimecomponent_controller.go
+++ b/controllers/runtimecomponent_controller.go
@@ -135,6 +135,20 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return reconcile.Result{}, err
 	}
 
+	isKnativeSupported, err := r.IsGroupVersionSupported(servingv1.SchemeGroupVersion.String(), "Service")
+	if err != nil {
+		r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+	} else if !isKnativeSupported {
+		reqLogger.V(1).Info(fmt.Sprintf("%s is not supported on the cluster", servingv1.SchemeGroupVersion.String()))
+	}
+
+	// Check if there is an existing Deployment, Statefulset or Knative service by this name
+	// not managed by this operator
+	err = appstacksutils.CheckForNameConflicts("RuntimeComponent", instance.Name, instance.Namespace, r.GetClient(), req, isKnativeSupported)
+	if err != nil {
+		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
+	}
+
 	// initialize the RuntimeComponent instance
 	instance.Initialize()
 	_, err = appstacksutils.Validate(instance)
@@ -225,20 +239,6 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	saErr := appstacksutils.ServiceAccountPullSecretExists(instance, r.GetClient())
 	if saErr != nil {
 		return r.ManageError(saErr, common.StatusConditionTypeReconciled, instance)
-	}
-
-	isKnativeSupported, err := r.IsGroupVersionSupported(servingv1.SchemeGroupVersion.String(), "Service")
-	if err != nil {
-		r.ManageError(err, common.StatusConditionTypeReconciled, instance)
-	} else if !isKnativeSupported {
-		reqLogger.V(1).Info(fmt.Sprintf("%s is not supported on the cluster", servingv1.SchemeGroupVersion.String()))
-	}
-
-	// Check if there is an existing Deployment, Statefulset or Knative service by this name
-	// not managed by this operator
-	err = appstacksutils.CheckForExistingDeployments("RuntimeComponent", instance.Name, instance.Namespace, r.GetClient(), req, isKnativeSupported)
-	if err != nil {
-		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 	}
 
 	if instance.Spec.CreateKnativeService != nil && *instance.Spec.CreateKnativeService {

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -268,7 +268,7 @@ bundle() {
     echo "------------"
     echo "bundle-push"
     echo "------------"
-    make  -C  $MAKEFILE_DIR bundle-push PUBLISH_REGISTRY=$OCP_REGISTRY_URL BUNDLE_IMG=$NAMESPACE/$OPERATOR_NAME-bundle:$VVERSION TLS_VERIFY=false
+    make  -C  $MAKEFILE_DIR bundle-push VERSION=$VVERSION IMG=$IMG IMAGE_TAG_BASE=$IMAGE_TAG_BASE BUNDLE_IMG=$BUNDLE_IMG CATALOG_IMG=$CATALOG_IMG TLS_VERIFY=false
 }
 
 ###################################

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1572,7 +1572,7 @@ func GetIssuerResourceVersion(client client.Client, certificate *certmanagerv1.C
 	}
 }
 
-func CheckForExistingDeployments(operator string, name string, namespace string, client client.Client, request reconcile.Request, isKnativeSupported bool) error {
+func CheckForNameConflicts(operator string, name string, namespace string, client client.Client, request reconcile.Request, isKnativeSupported bool) error {
 	defaultMeta := metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,


### PR DESCRIPTION
**What this PR does / why we need it?**:

Checks to see if there is an existing Deployment, Statefulset or Knative service with the same name, and verifies
if it is managed by another operator.  If its not,  the status is updated to reflect the issue and it is re-queued. 


**Does this PR introduce a user-facing change?**
in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #  https://github.com/WASdev/websphere-liberty-operator/issues/179
