### PR TITLE
Build images with GitHub tags

### DIFF
--- a/ebcDockerBuilderRCO.jenkinsfile
+++ b/ebcDockerBuilderRCO.jenkinsfile
@@ -85,6 +85,7 @@ timestamps {
 def gitCloneAndStash() {
   dir('runtime-component-operator') {
       git branch: RELEASE_TARGET, url: "git@github.com:${scriptOrg}/runtime-component-operator.git"
+      sh "git checkout ${RELEASE_TARGET}"
   }
   dir('operators') {
       git branch: "main", url: "git@github.ibm.com:websphere/operators.git"

--- a/scripts/pipeline/request-ciorchestrator.sh
+++ b/scripts/pipeline/request-ciorchestrator.sh
@@ -114,7 +114,7 @@ function request_ciorchestrator() {
             "apiRoot": "${GH_API_ROOT}",
             "org": "${GH_ORG}",
             "repo": "${GH_REPOSITORY}",
-            "branch": "${GH_BRANCH}",
+            "branch": "main",
             "filePath": "${CI_CONFIG_FILE}"
         }
     }


### PR DESCRIPTION
**What this PR does / why we need it?**:

CI Orchestrator doesn't support GitHub tags. It only supports branches. Use the following workarounds suggested by the CI Orchestrator team:
- reference the request-orchestrator from `main` branch (similar to https://github.com/WASdev/websphere-liberty-operator/pull/436)
- checkout the tag so that the orchestrator can build images on Jenkins

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
