### PR TITLE
Build images with GitHub tags

### DIFF
--- a/ebcDockerBuilderRCO.jenkinsfile
+++ b/ebcDockerBuilderRCO.jenkinsfile
@@ -84,7 +84,8 @@ timestamps {
 // Clone the git repo and stash it, so that the jenkins agent machine can grab it later
 def gitCloneAndStash() {
   dir('runtime-component-operator') {
-      git branch: RELEASE_TARGET, url: "git@github.com:${scriptOrg}/runtime-component-operator.git"
+      git branch: "main", url: "git@github.com:${scriptOrg}/runtime-component-operator.git"
+      sh "git checkout ${RELEASE_TARGET}"
   }
   dir('operators') {
       git branch: "main", url: "git@github.ibm.com:websphere/operators.git"


### PR DESCRIPTION
**What this PR does / why we need it?**:
CI Orchestrator doesn't support GitHub tags. It only supports branches. Use the following workaround suggested by the CI Orchestrator team: checkout the tag so that the orchestrator can build images on Jenkins

Similar to WLO PR https://github.com/WASdev/websphere-liberty-operator/pull/444

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
