### PR TITLE
Set security context on Knative service and add new visibility label

### DIFF
--- a/controllers/runtimecomponent_controller.go
+++ b/controllers/runtimecomponent_controller.go
@@ -270,16 +270,17 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 
 		if isKnativeSupported {
+			reqLogger.Info("Knative is supported and Knative Service is enabled")
 			ksvc := &servingv1.Service{ObjectMeta: defaultMeta}
 			err = r.CreateOrUpdate(ksvc, instance, func() error {
 				appstacksutils.CustomizeKnativeService(ksvc, instance)
 				return nil
 			})
-
 			if err != nil {
 				reqLogger.Error(err, "Failed to reconcile Knative Service")
 				return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 			}
+			reqLogger.Info("Reconcile RuntimeComponent - completed")
 			return r.ManageSuccess(common.StatusConditionTypeReconciled, instance)
 		}
 		return r.ManageError(errors.New("failed to reconcile Knative service as operator could not find Knative CRDs"), common.StatusConditionTypeReconciled, instance)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -831,8 +831,10 @@ func CustomizeKnativeService(ksvc *servingv1.Service, ba common.BaseComponent) {
 	// If `expose` is not set to `true`, make Knative route a private route by adding `serving.knative.dev/visibility: cluster-local`
 	// to the Knative service. If `serving.knative.dev/visibility: XYZ` is defined in cr.Labels, `expose` always wins.
 	if ba.GetExpose() != nil && *ba.GetExpose() {
+		delete(ksvc.Labels, "networking.knative.dev/visibility")
 		delete(ksvc.Labels, "serving.knative.dev/visibility")
 	} else {
+		ksvc.Labels["networking.knative.dev/visibility"] = "cluster-local"
 		ksvc.Labels["serving.knative.dev/visibility"] = "cluster-local"
 	}
 
@@ -865,6 +867,8 @@ func CustomizeKnativeService(ksvc *servingv1.Service, ba common.BaseComponent) {
 	ksvc.Spec.Template.Spec.Containers[0].ImagePullPolicy = *ba.GetPullPolicy()
 	ksvc.Spec.Template.Spec.Containers[0].Env = ba.GetEnv()
 	ksvc.Spec.Template.Spec.Containers[0].EnvFrom = ba.GetEnvFrom()
+
+	ksvc.Spec.Template.Spec.Containers[0].SecurityContext = GetSecurityContext(ba)
 
 	ksvc.Spec.Template.Spec.Containers[0].VolumeMounts = ba.GetVolumeMounts()
 	ksvc.Spec.Template.Spec.Volumes = ba.GetVolumes()


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Set the security context on Knative Service (user specified or the default - the default matches what's set by Knative itself otherwise)
- Knative changed the label used to control visibility of route (adding the new label for now, we could remove the old label in the future if it's 100% not needed) - PR for https://github.com/application-stacks/runtime-component-operator/issues/515

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
