### PR TITLE
Set ecosystemRouting to prod in ciorchestrator req

### DIFF
--- a/scripts/pipeline/request-ciorchestrator.sh
+++ b/scripts/pipeline/request-ciorchestrator.sh
@@ -91,7 +91,7 @@ function request_ciorchestrator() {
     cat >ciorchestrator-submit.json <<EOL
     {
         "type": "PipelineTriggered",
-        "ecosystemRouting": "dev",
+        "ecosystemRouting": "prod",
         "pipelineId": "${pipelineId}",
         "pipelineName": "${pipelineName}",
         "triggerName": "${CI_TRIGGER}",


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Set ecosystemRouting to prod in ciorchestrator req - similar to WLO and also suggested by Chris Webster([here](https://ibm-cloud.slack.com/archives/C31GDF6CD/p1682335003231549?thread_ts=1680723628.432789&cid=C31GDF6CD))


**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
