### PR TITLE
Add getting started image back to the tests

### DIFF
--- a/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/03-assert.yaml
@@ -43,9 +43,6 @@ spec:
           successThreshold: 1
           failureThreshold: 20
 status:
-# not checking readyReplicas or replicas while using icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi 
-# as it uses different default ports. Replace with icr.io/appcafe/open-liberty/samples/getting-started 
-# when available
-#  readyReplicas: 1
-#  replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/03-runtime-probe-defaults.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/03-runtime-probe-defaults.yaml
@@ -4,7 +4,7 @@ metadata:
   name: probes-rc
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started
   manageTLS: false
   service:
     port: 9443

--- a/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/04-assert.yaml
@@ -43,9 +43,6 @@ spec:
             successThreshold: 1
             failureThreshold: 5
 status:
-# not checking readyReplicas or replicas while using icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi 
-# as it uses different default ports. Replace with icr.io/appcafe/open-liberty/samples/getting-started 
-# when available
-#  readyReplicas: 1
-#  replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1

--- a/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/probe/05-assert.yaml
@@ -23,9 +23,6 @@ spec:
           successThreshold: 1
           failureThreshold: 20
 status:
-# not checking readyReplicas or replicas while using icr.io/appcafe/websphere-liberty:full-java8-openj9-ubi 
-# as it uses different default ports. Replace with icr.io/appcafe/open-liberty/samples/getting-started 
-# when available
-#  readyReplicas: 1
-#  replicas: 1
+  readyReplicas: 1
+  replicas: 1
   updatedReplicas: 1


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Reverted changes make to kuttl e2e tests now that the getting started app is multiarch