### PR TITLE
prometheus insists scheme is 'https' not 'HTTPS'

### DIFF
--- a/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-assert.yaml
@@ -21,7 +21,7 @@ spec:
       app.kubernetes.io/instance: service-monitor-rc
   endpoints:
   - path: "/path"
-    scheme: "myScheme"
+    scheme: "https"
     port: 3000-tcp
     params:
       params:

--- a/bundle/tests/scorecard/kuttl/monitor/02-runtime-update-monitor.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/02-runtime-update-monitor.yaml
@@ -6,7 +6,7 @@ spec:
   monitoring:
     endpoints:
     - path: "/path"
-      scheme: "myScheme"
+      scheme: "https"
       params:
         params:
         - "param1"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1040,7 +1040,7 @@ func CustomizeServiceMonitor(sm *prometheusv1.ServiceMonitor, ba common.BaseComp
 	}
 	if ba.GetManageTLS() == nil || *ba.GetManageTLS() {
 		if len(ba.GetMonitoring().GetEndpoints()) == 0 || ba.GetMonitoring().GetEndpoints()[0].TLSConfig == nil {
-			sm.Spec.Endpoints[0].Scheme = "HTTPS"
+			sm.Spec.Endpoints[0].Scheme = "https"
 			if sm.Spec.Endpoints[0].TLSConfig == nil {
 				sm.Spec.Endpoints[0].TLSConfig = &prometheusv1.TLSConfig{}
 			}


### PR DESCRIPTION
Newer versions of prometheus don't seem to like uppercase

Currently the monitor test passes if you run against an OCP cluster, but fails in Kind clusters. This should now pass everywhere.

This looks like it has been caused by this commit in prometheus:
https://github.com/prometheus-operator/prometheus-operator/commit/28e0383b9e50922cccfc9e63d2ced3420c4794ae
which has added scheme validation, and only allows http or https as valid values.