### PR TITLE
Add tags to test docker images to reduce pulls

### DIFF
--- a/bundle/tests/scorecard/kuttl/day2operation/00-runtime.yaml
+++ b/bundle/tests/scorecard/kuttl/day2operation/00-runtime.yaml
@@ -4,7 +4,7 @@ metadata:
   name: day2-operation-rc
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   replicas: 1
   statefulSet:
     storage:

--- a/bundle/tests/scorecard/kuttl/env/01-runtime-env.yaml
+++ b/bundle/tests/scorecard/kuttl/env/01-runtime-env.yaml
@@ -4,7 +4,7 @@ metadata:
   name: env-rc
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   replicas: 1
   env:
     - name: TEST_VALUE

--- a/bundle/tests/scorecard/kuttl/env/03-runtime-statefulset-env.yaml
+++ b/bundle/tests/scorecard/kuttl/env/03-runtime-statefulset-env.yaml
@@ -4,7 +4,7 @@ metadata:
   name: env-rc
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   replicas: 1
   statefulSet: {}
   env:

--- a/bundle/tests/scorecard/kuttl/image-stream/04-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/04-assert.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-      - image: icr.io/appcafe/open-liberty
+      - image: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
 status:
   replicas: 1
   readyReplicas: 1
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-  - image: icr.io/appcafe/open-liberty
+  - image: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
 metadata:
   labels:
     app.kubernetes.io/instance: imagestream-rc

--- a/bundle/tests/scorecard/kuttl/image-stream/04-runtime-no-stream.yaml
+++ b/bundle/tests/scorecard/kuttl/image-stream/04-runtime-no-stream.yaml
@@ -4,5 +4,5 @@ metadata:
   name: imagestream-rc
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
 

--- a/bundle/tests/scorecard/kuttl/knative/00-runtime-no-knative.yaml
+++ b/bundle/tests/scorecard/kuttl/knative/00-runtime-no-knative.yaml
@@ -6,7 +6,7 @@ metadata:
   name: knative1-rc
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   replicas: 1
   createKnativeService: false
 

--- a/bundle/tests/scorecard/kuttl/knative2/00-runtime-knative.yaml
+++ b/bundle/tests/scorecard/kuttl/knative2/00-runtime-knative.yaml
@@ -4,7 +4,7 @@ metadata:
   name: knative2-rc
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   replicas: 1
   createKnativeService: true
 

--- a/bundle/tests/scorecard/kuttl/monitor/00-runtime-basic.yaml
+++ b/bundle/tests/scorecard/kuttl/monitor/00-runtime-basic.yaml
@@ -4,7 +4,7 @@ metadata:
   name: service-monitor-rc
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   service:
     type: "ClusterIP"
     port: 3000

--- a/bundle/tests/scorecard/kuttl/nodeport/00-add-nodeport.yaml
+++ b/bundle/tests/scorecard/kuttl/nodeport/00-add-nodeport.yaml
@@ -3,7 +3,7 @@ kind: RuntimeComponent
 metadata:
   name: nodeport-rc
 spec:
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   service:
     nodePort: 30000
     port: 3000

--- a/bundle/tests/scorecard/kuttl/persistent-storage/00-persistent-storage-rc.yaml
+++ b/bundle/tests/scorecard/kuttl/persistent-storage/00-persistent-storage-rc.yaml
@@ -3,7 +3,7 @@ kind: RuntimeComponent
 metadata:
   name: persistent-rc
 spec:
-  applicationImage: icr.io/appcafe/open-liberty
+  applicationImage: icr.io/appcafe/open-liberty:full-java8-openj9-ubi
   replicas: 1
   volumeMounts:
     - name: pvc


### PR DESCRIPTION
If images don't have tags, then the default pull policy is always. Add tags to improve performance in the build, by reducing pulls
