### PR TITLE
Update RCO version to 1.2.1 and update catalog base image and OPM versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ARG USER_ID=65532
 ARG GROUP_ID=65532
 
-ARG VERSION_LABEL=1.2.0
+ARG VERSION_LABEL=1.2.1
 ARG RELEASE_LABEL=XX
 ARG VCS_REF=0123456789012345678901234567890123456789
 ARG VCS_URL="https://github.com/application-stacks/runtime-component-operator"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.2.0
+VERSION ?= 1.2.1
 OPERATOR_SDK_RELEASE_VERSION ?= v1.24.0
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle/manifests/runtime-component.clusterserviceversion.yaml
+++ b/bundle/manifests/runtime-component.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
             "name": "runtimecomponent-sample"
           },
           "spec": {
-            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860",
+            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80",
             "expose": true,
             "manageTLS": true,
             "replicas": 1,
@@ -41,7 +41,7 @@ metadata:
             "name": "runtimecomponent-sample"
           },
           "spec": {
-            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860",
+            "applicationImage": "icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80",
             "expose": true,
             "replicas": 1,
             "service": {
@@ -68,7 +68,7 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: icr.io/appcafe/runtime-component-operator:daily
-    createdAt: "2023-06-15T17:15:41Z"
+    createdAt: "2023-06-15T17:18:00Z"
     description: Deploys any runtime component with dynamic and auto-tuning configuration
     olm.skipRange: '>=0.8.0 <1.2.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -976,7 +976,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-                  value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+                  value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
                 image: icr.io/appcafe/runtime-component-operator:daily
                 livenessProbe:
                   failureThreshold: 3
@@ -1257,6 +1257,6 @@ spec:
   provider:
     name: Community
   relatedImages:
-  - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+  - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
     name: liberty-sample-app
   version: 1.2.1

--- a/bundle/manifests/runtime-component.clusterserviceversion.yaml
+++ b/bundle/manifests/runtime-component.clusterserviceversion.yaml
@@ -68,9 +68,9 @@ metadata:
     categories: Application Runtime
     certified: "true"
     containerImage: icr.io/appcafe/runtime-component-operator:daily
-    createdAt: "2023-05-01T09:45:40Z"
+    createdAt: "2023-06-15T17:15:41Z"
     description: Deploys any runtime component with dynamic and auto-tuning configuration
-    olm.skipRange: '>=0.8.0 <1.2.0'
+    olm.skipRange: '>=0.8.0 <1.2.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -81,7 +81,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: runtime-component.v1.2.0
+  name: runtime-component.v1.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1259,4 +1259,4 @@ spec:
   relatedImages:
   - image: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
     name: liberty-sample-app
-  version: 1.2.0
+  version: 1.2.1

--- a/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/basic/00-assert.yaml
@@ -13,4 +13,4 @@ metadata:
   name: example-runtime-component
 status:
   versions:
-    reconciled: 1.2.0
+    reconciled: 1.2.1

--- a/bundle/tests/scorecard/kuttl/day2operation/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/day2operation/01-assert.yaml
@@ -12,4 +12,4 @@ status:
      - status: 'True'
        type: Completed
   versions:
-    reconciled: 1.2.0
+    reconciled: 1.2.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,7 +67,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.annotations['olm.targetNamespaces']
           - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-            value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+            value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/config/manifests/bases/runtime-component.clusterserviceversion.yaml
+++ b/config/manifests/bases/runtime-component.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     containerImage: icr.io/appcafe/runtime-component-operator:daily
     createdAt: "2022-02-25T09:00:00Z"
     description: Deploys any runtime component with dynamic and auto-tuning configuration
-    olm.skipRange: '>=0.8.0 <1.2.0'
+    olm.skipRange: '>=0.8.0 <1.2.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/application-stacks/runtime-component-operator
     support: Community

--- a/config/samples/rc.app.stacks_v1_runtimecomponent.yaml
+++ b/config/samples/rc.app.stacks_v1_runtimecomponent.yaml
@@ -3,7 +3,7 @@ kind: RuntimeComponent
 metadata:
   name: runtimecomponent-sample
 spec:
-  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
   expose: true
   manageTLS: true
   replicas: 1

--- a/config/samples/rc.app.stacks_v1beta2_runtimecomponent.yaml
+++ b/config/samples/rc.app.stacks_v1beta2_runtimecomponent.yaml
@@ -4,7 +4,7 @@ metadata:
   name: runtimecomponent-sample
 spec:
   # Add fields here
-  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+  applicationImage: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
   expose: true
   replicas: 1
   service:

--- a/ebcDockerBuilderRCO.jenkinsfile
+++ b/ebcDockerBuilderRCO.jenkinsfile
@@ -11,7 +11,7 @@ properties([
       string(name: 'command', defaultValue: "make build-operator-pipeline REGISTRY=cp.stg.icr.io", description: 'Build command to execute on target arch machine, e.g. make build-pipeline-releases'),
       string(name: 'PIPELINE_OPERATOR_IMAGE', defaultValue: "cp/runtime-component-operator", description: 'namespace to push image to in registry'),
       string(name: 'RELEASE_TARGET', defaultValue: "main", description: 'release branch to use'),
-      string(name: 'OPM_VERSION', defaultValue: "4.10", description: 'Redhat CLI OPM version'),
+      string(name: 'OPM_VERSION', defaultValue: "4.12", description: 'Redhat CLI OPM version'),
       string(name: 'PIPELINE_PRODUCTION_IMAGE', defaultValue: "icr.io/cpopen/runtime-component-operator", description: 'namespace in prod registry'),
       string(name: 'REDHAT_BASE_IMAGE', defaultValue: "registry.redhat.io/openshift4/ose-operator-registry", description: 'base image for operator'),
       string(name: 'REDHAT_REGISTRY', defaultValue: "registry.redhat.io", description: 'RH registry used for docker login'),

--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.10 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12 AS builder
 
 FROM registry.redhat.io/ubi8/ubi-minimal
 

--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -2,7 +2,7 @@ FROM registry.redhat.io/openshift4/ose-operator-registry:v4.10 AS builder
 
 FROM registry.redhat.io/ubi8/ubi-minimal
 
-ARG VERSION_LABEL=1.2.0
+ARG VERSION_LABEL=1.2.1
 ARG RELEASE_LABEL=XX
 ARG VCS_REF=0123456789012345678901234567890123456789
 ARG VCS_URL="https://github.com/application-stacks/runtime-component-operator"

--- a/internal/deploy/kubectl/runtime-component-operator.yaml
+++ b/internal/deploy/kubectl/runtime-component-operator.yaml
@@ -303,7 +303,7 @@ spec:
         - name: WATCH_NAMESPACE
           value: RUNTIME_COMPONENT_WATCH_NAMESPACE
         - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
         image: icr.io/appcafe/runtime-component-operator:daily
         livenessProbe:
           failureThreshold: 3

--- a/internal/deploy/kustomize/daily/base/runtime-component-operator.yaml
+++ b/internal/deploy/kustomize/daily/base/runtime-component-operator.yaml
@@ -50,7 +50,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
-          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:e22dd56a05e44618a10d275d3ff07a38eb364c0f04f86ffe9618d83dd5467860
+          value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:b0d658e07e656a8cb3b02bf7194f788f4456c7ffe9d3361f96ac2807045dad80
         image: icr.io/appcafe/runtime-component-operator:daily
         livenessProbe:
           failureThreshold: 3

--- a/scripts/installers/install-opm.sh
+++ b/scripts/installers/install-opm.sh
@@ -9,7 +9,7 @@ main() {
     exit 0
   fi
 
-  readonly DEFAULT_RELEASE_VERSION=latest-4.10
+  readonly DEFAULT_RELEASE_VERSION=latest-4.12
   readonly RELEASE_VERSION=${1:-$DEFAULT_RELEASE_VERSION}
   readonly base_url="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${RELEASE_VERSION}"
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const RCOOperandVersion = "1.2.0"
+const RCOOperandVersion = "1.2.1"
 
 var APIVersionNotFoundError = errors.New("APIVersion is not available")
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Update the RCO version to 1.2.1
- Update the catalog base image (to resolve CVEs) and OPM version to 4.12. OCP 4.10 is supported till September 2023, so left the OC CLI version at 4.10 for now. 
- Update sample app

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
