### PR TITLE
Added auto generation for kustomize artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,9 @@ bundle: manifests setup kustomize ## Generate bundle manifests and metadata, the
 	$(KUSTOMIZE) build config/kubectl/rbac-watch-all -o internal/deploy/kubectl/runtime-component-rbac-watch-all.yaml
 	$(KUSTOMIZE) build config/kubectl/rbac-watch-another -o internal/deploy/kubectl/runtime-component-rbac-watch-another.yaml
 
+	$(KUSTOMIZE) build config/kustomize/watch-all -o internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
+	$(KUSTOMIZE) build config/kustomize/watch-another -o internal/deploy/kustomize/daily/overlays/watch-another-namespace/rco-watched-ns/watched-roles.yaml
+
 	operator-sdk bundle validate ./bundle
 
 .PHONY: fmt

--- a/config/kustomize/watch-all/kustomization.yaml
+++ b/config/kustomize/watch-all/kustomization.yaml
@@ -1,0 +1,93 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../rbac
+
+# Labels to add to all resources and selectors.
+commonLabels:
+  app.kubernetes.io/instance: runtime-component-operator
+  app.kubernetes.io/name: runtime-component-operator
+
+patches:
+- path: patches/delete-service-account.yaml
+  target:
+    kind: ServiceAccount
+
+patchesJson6902:
+  - target:
+      namespace: runtime-component-operator
+      name: .*
+    patch: |-
+      - op: remove
+        path: /metadata/namespace
+  - target:
+      kind: Role
+      name: .*
+    patch: |-
+      - op: replace
+        path: /kind
+        value: ClusterRole
+  - target:
+      kind: RoleBinding
+      name: .*
+    patch: |-
+      - op: replace
+        path: /kind
+        value: ClusterRoleBinding
+  - target:
+      kind: ClusterRoleBinding
+      name: .*
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: rco-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: RUNTIME_COMPONENT_OPERATOR_NAMESPACE
+      - op: replace
+        path: /roleRef/kind
+        value: ClusterRole
+  - target:
+      kind: ClusterRoleBinding
+      name: leader-election-rolebinding
+    patch: |-
+      - op: replace
+        path: /roleRef/name
+        value: rco-leader-election-cluster-role
+      - op: replace
+        path: /metadata/name
+        value: rco-leader-election-cluster-rolebinding
+  - target:
+      kind: ClusterRoleBinding
+      name: manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: rco-manager-cluster-rolebinding
+      - op: replace
+        path: /roleRef/name
+        value: rco-manager-cluster-role
+  - target:
+      kind: ClusterRole
+      name: manager-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: rco-manager-cluster-role
+      - op: add
+        path: /rules/-
+        value: {"apiGroups":[""],"resources":["namespaces"],"verbs":["get","list","watch"]}
+  - target:
+      kind: ClusterRoleBinding
+      name: .*
+    patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: runtime-component
+  - target:
+      kind: ClusterRole
+      name: leader-election-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: rco-leader-election-cluster-role

--- a/config/kustomize/watch-all/patches/delete-service-account.yaml
+++ b/config/kustomize/watch-all/patches/delete-service-account.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wlo-controller-manager

--- a/config/kustomize/watch-another/kustomization.yaml
+++ b/config/kustomize/watch-another/kustomization.yaml
@@ -1,0 +1,62 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../rbac
+
+namespace: rco-watched-ns
+
+# Labels to add to all resources and selectors.
+commonLabels:
+  app.kubernetes.io/instance: runtime-component-operator
+  app.kubernetes.io/name: runtime-component-operator
+
+patches:
+- path: patches/delete-service-account.yaml
+  target:
+    kind: ServiceAccount
+
+patchesJson6902:
+  - target:
+      kind: RoleBinding
+      name: manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: rco-watched-rolebinding
+      - op: replace
+        path: /roleRef/name
+        value: rco-watched-role
+  - target:
+      kind: RoleBinding
+      name: leader-election-rolebinding
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: rco-leader-election-watched-rolebinding
+      - op: replace
+        path: /roleRef/name
+        value: rco-leader-election-watched-role
+  - target:
+      kind: RoleBinding
+      name: .*
+    patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: rco-ns
+      - op: replace
+        path: /subjects/0/name
+        value: rco-controller-manager
+  - target:
+      kind: Role
+      name: leader-election-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: rco-leader-election-watched-role
+  - target:
+      kind: Role
+      name: manager-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: rco-watched-role

--- a/config/kustomize/watch-another/patches/delete-service-account.yaml
+++ b/config/kustomize/watch-another/patches/delete-service-account.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wlo-controller-manager

--- a/internal/deploy/kustomize/daily/base/runtime-component-operator.yaml
+++ b/internal/deploy/kustomize/daily/base/runtime-component-operator.yaml
@@ -51,7 +51,7 @@ spec:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_LIBERTY_SAMPLE_APP
           value: icr.io/appcafe/open-liberty/samples/getting-started@sha256:d3c67c4a15c97b0fb82f9ef4a2ccf474232b878787e9eea39af75a3ac78469e3
-        image: icr.io/appcafe/runtime-component-operator:daily
+        image: icr.io/appcafe/runtime-component-operator:1.2.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-all-namespaces/cluster-roles.yaml
@@ -220,8 +220,8 @@ rules:
   resources:
   - namespaces
   verbs:
-  - list
   - get
+  - list
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -255,4 +255,3 @@ subjects:
 - kind: ServiceAccount
   name: rco-controller-manager
   namespace: runtime-component
----

--- a/internal/deploy/kustomize/daily/overlays/watch-another-namespace/rco-watched-ns/watched-roles.yaml
+++ b/internal/deploy/kustomize/daily/overlays/watch-another-namespace/rco-watched-ns/watched-roles.yaml
@@ -1,6 +1,55 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    app.kubernetes.io/instance: runtime-component-operator
+    app.kubernetes.io/name: runtime-component-operator
+  name: rco-leader-election-watched-role
+  namespace: rco-watched-ns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: runtime-component-operator
@@ -175,72 +224,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: runtime-component-operator
     app.kubernetes.io/name: runtime-component-operator
-  name: rco-watched-rolebinding
-  namespace: rco-watched-ns
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: rco-watched-role
-subjects:
-- kind: ServiceAccount
-  name: rco-controller-manager
-  namespace: rco-ns
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    app.kubernetes.io/instance: runtime-component-operator
-    app.kubernetes.io/name: runtime-component-operator
-  name: rco-leader-election-watched-role
-  namespace: rco-watched-ns
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/instance: runtime-component-operator
-    app.kubernetes.io/name: runtime-component-operator
   name: rco-leader-election-watched-rolebinding
   namespace: rco-watched-ns
 roleRef:
@@ -252,4 +235,19 @@ subjects:
   name: rco-controller-manager
   namespace: rco-ns
 ---
-
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: runtime-component-operator
+    app.kubernetes.io/name: runtime-component-operator
+  name: rco-watched-rolebinding
+  namespace: rco-watched-ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rco-watched-role
+subjects:
+- kind: ServiceAccount
+  name: rco-controller-manager
+  namespace: rco-ns


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Adds in auto generation for kustomize artifacts
- Updates the current artifacts with the output from the generator

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Related [websphere-liberty-operator/issues/446](https://github.com/WASdev/websphere-liberty-operator/issues/446)
