### PR TITLE
Update alpine image to ubi9-micro

### DIFF
--- a/bundle/tests/scorecard/kuttl/init-deployment/01-add-init-container.yaml
+++ b/bundle/tests/scorecard/kuttl/init-deployment/01-add-init-container.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Add fields here
   initContainers:
-  - image: alpine:3.14
+  - image: registry.redhat.io/ubi9-micro:9.2-15
     command: ["echo"]
     args: ["Hello world"]
     name: init1

--- a/bundle/tests/scorecard/kuttl/init-stateful/01-add-init-container.yaml
+++ b/bundle/tests/scorecard/kuttl/init-stateful/01-add-init-container.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Add fields here
   initContainers:
-  - image: alpine:3.14
+  - image: registry.redhat.io/ubi9-micro:9.2-15
     command: ["echo"]
     args: ["Hello world"]
     name: init1


### PR DESCRIPTION
Resolves intermittent failures when creating the initContainer in the `init-deployment` and `init-statefulset` scorecard tests. Related issue: https://github.com/OpenLiberty/open-liberty-operator/issues/464 