### PR TITLE
Don't put 'autoscaling.knative.dev' annotations directly on the knati…

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -840,7 +840,7 @@ func removePullSecret(sa *corev1.ServiceAccount, pullSecretName string) {
 func CustomizeKnativeService(ksvc *servingv1.Service, ba common.BaseComponent) {
 	obj := ba.(metav1.Object)
 	ksvc.Labels = ba.GetLabels()
-	ksvc.Annotations = MergeMaps(ksvc.Annotations, ba.GetAnnotations())
+	ksvc.Annotations = filterMerge("autoscaling.knative.dev/", ksvc.Annotations, ba.GetAnnotations())
 
 	// If `expose` is not set to `true`, make Knative route a private route by adding `serving.knative.dev/visibility: cluster-local`
 	// to the Knative service. If `serving.knative.dev/visibility: XYZ` is defined in cr.Labels, `expose` always wins.
@@ -1117,6 +1117,22 @@ func MergeMaps(maps ...map[string]string) map[string]string {
 		}
 	}
 
+	return dest
+}
+
+// filterMerge merges maps as per MergeMaps, but will filter out any keys which
+// match keyFilterPrefix
+func filterMerge(keyFilterPrefix string, maps ...map[string]string) map[string]string {
+	dest := make(map[string]string)
+
+	for i := range maps {
+		for key, value := range maps[i] {
+			if strings.HasPrefix(key, keyFilterPrefix) {
+				continue
+			}
+			dest[key] = value
+		}
+	}
 	return dest
 }
 


### PR DESCRIPTION
…ve Service

As this fails validation of the Service resource

This is to fix issue OpenLiberty/open-liberty-operator#474

Looks to have been ultimately caused by:
https://github.com/knative/serving/pull/9358/commits/4ea3e296ca75de307e6ec59edd781c1d69c2ff78


