### PR TITLE
Bug fix: create default service account if name not specified

### DIFF
--- a/controllers/runtimecomponent_controller.go
+++ b/controllers/runtimecomponent_controller.go
@@ -205,7 +205,7 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	if instance.Spec.ServiceAccountName == nil || *instance.Spec.ServiceAccountName == "" {
+	if appstacksutils.GetServiceAccountName(instance) == "" {
 		serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
 		err = r.CreateOrUpdate(serviceAccount, instance, func() error {
 			return appstacksutils.CustomizeServiceAccount(serviceAccount, instance, r.GetClient())
@@ -215,6 +215,7 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 		}
 	} else {
+		// delete our SA, as one has been specified
 		serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
 		err = r.DeleteResource(serviceAccount)
 		if err != nil {


### PR DESCRIPTION
The previous change to deprecate .spec.ServiceAccountName was not reflected in the controller where the default service account is created. Use the new utils method to check if a service account has been specified before creating the default account

This change was missed from the initial fix for 
https://github.com/OpenLiberty/open-liberty-operator/issues/462
