### PR TITLE
Use reader client to get operator config map

### DIFF
--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -168,7 +168,7 @@ func (r *ReconcilerBase) DeleteResources(resources []client.Object) error {
 // GetOpConfigMap ...
 func (r *ReconcilerBase) GetOpConfigMap(name string, ns string) (*corev1.ConfigMap, error) {
 	configMap := &corev1.ConfigMap{}
-	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: name, Namespace: ns}, configMap)
+	err := r.GetAPIReader().Get(context.TODO(), types.NamespacedName{Name: name, Namespace: ns}, configMap)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/reconciler_test.go
+++ b/utils/reconciler_test.go
@@ -264,7 +264,7 @@ func TestGetOpConfigMap(t *testing.T) {
 	objs, s := []runtime.Object{runtimecomponent}, scheme.Scheme
 	s.AddKnownTypes(appstacksv1.GroupVersion, runtimecomponent)
 	cl := fakeclient.NewFakeClient(objs...)
-	rcl := fakeclient.NewFakeClient(objs...)
+	rcl := cl
 
 	r := NewReconcilerBase(rcl, cl, s, &rest.Config{}, record.NewFakeRecorder(10))
 


### PR DESCRIPTION
The operator config map is not always in the same namespace that is being watched, and the client provided by the manager will only read resources in the watched namespace. 'Get' on the configmap will fail in this situation

Use the reader client instead, as this will read resources from any namespace

fixes #590