### PR TITLE
Remove Travis instances in One Pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ catalog-build: opm ## Build a catalog image.
 	$(OPM) index add $(SKIP_TLS_VERIFY) --container-tool $(CONTAINER_COMMAND)  --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT) --permissive
 
 kind-e2e-test:
-	./operators/scripts/test/e2e-kind.sh --test-tag "${TRAVIS_BUILD_NUMBER}"
+	./operators/scripts/test/e2e-kind.sh --test-tag "${BUILD_NUMBER}"
 
 build-manifest: setup-manifest
 	./operators/scripts/build/build-manifest.sh --registry "${PUBLISH_REGISTRY}" --image "${OPERATOR_IMAGE}" --tag "${RELEASE_TARGET}"
@@ -349,7 +349,7 @@ test-pipeline-e2e:
                      --cluster-url "${CLUSTER_URL}" --cluster-user "${CLUSTER_USER}" --cluster-token "${CLUSTER_TOKEN}" \
                      --registry-name "${PIPELINE_REGISTRY}" --registry-image "${PIPELINE_OPERATOR_IMAGE}" \
                      --registry-user "${PIPELINE_USERNAME}" --registry-password "${PIPELINE_PASSWORD}" \
-                     --test-tag "${TRAVIS_BUILD_NUMBER}" --release "${RELEASE_TARGET}" --channel "${DEFAULT_CHANNEL}" \
+                     --test-tag "${BUILD_NUMBER}" --release "${RELEASE_TARGET}" --channel "${DEFAULT_CHANNEL}" \
 					 --install-mode "${INSTALL_MODE}" --architecture "${ARCHITECTURE}" \
 					 --digest "${DIGEST}" --version "${VERSION}"
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Removing Travis instances
- Related: https://github.ibm.com/websphere/operators/pull/100

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Related https://github.com/WASdev/websphere-liberty-operator/issues/618
