### PR TITLE
Add thread safety to support multiple concurrent reconciles

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -53,7 +53,11 @@ const (
 )
 
 // Config stores operator configuration
-var Config = &sync.Map{}
+var Config *sync.Map
+
+func init() {
+	Config = &sync.Map{}
+}
 
 var LevelFunc = uberzap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
 	return lvl >= Config.GetZapLogLevel()

--- a/common/config.go
+++ b/common/config.go
@@ -60,11 +60,11 @@ func init() {
 }
 
 var LevelFunc = uberzap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-	return lvl >= Config.GetZapLogLevel()
+	return lvl >= GetZapLogLevel(Config)
 })
 
 var StackLevelFunc = uberzap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-	configuredLevel := Config.GetZapLogLevel()
+	configuredLevel := GetZapLogLevel(Config)
 	if configuredLevel > zapcore.DebugLevel {
 		// No stack traces unless fine/finer/finest has been requested
 		// Zap's debug is mapped to fine
@@ -129,9 +129,9 @@ func SetConfigMapDefaultValue(oc *sync.Map, key string) {
 // Returns the zap log level corresponding to the value of the
 // 'logLevel' key in the config map. Returns 'info' if they key
 // is missing or contains an invalid value.
-func (oc OpConfig) GetZapLogLevel() zapcore.Level {
-	level, ok := oc[OpConfigLogLevel]
-	if !ok {
+func GetZapLogLevel(oc *sync.Map) zapcore.Level {
+	level := LoadFromConfig(oc, OpConfigLogLevel)
+	if level == "" {
 		return zLevelInfo
 	}
 	switch level {

--- a/common/config.go
+++ b/common/config.go
@@ -90,34 +90,17 @@ func LoadFromConfigMap(oc *sync.Map, cm *corev1.ConfigMap) {
 	}
 }
 
-// Loads the value stored in operator config's key or falls back to the operator default value
-func LoadConfigValueOrFallback(oc *sync.Map, key string) (string, error) {
+// Loads a string value stored at key in the sync.Map oc or "" if it does not exist
+func LoadFromConfig(oc *sync.Map, key string) string {
 	value, ok := oc.Load(key)
 	if !ok {
-		fallbackValue, fallbackErr := GetFallbackConfigValue(key)
-		if fallbackErr != nil {
-			return "", fallbackErr
-		}
-		return fallbackValue, nil
+		return ""
 	}
-	return value.(string), nil
-}
-
-// Gets the value associated with the operator default config if the key exists, otherwise return an error
-func GetFallbackConfigValue(key string) (string, error) {
-	fallbackConfig := DefaultOpConfig()
-	fallbackValue, fallbackOk := fallbackConfig.Load(key)
-	if !fallbackOk {
-		return "", errors.New("could not get value for key " + key + " in the default operator config")
-	}
-	return fallbackValue.(string), nil
+	return value.(string)
 }
 
 func CheckValidValue(oc *sync.Map, key string, OperatorName string) error {
-	value, err := LoadConfigValueOrFallback(oc, key)
-	if err != nil {
-		return err
-	}
+	value := LoadFromConfig(oc, key)
 
 	intValue, err := strconv.Atoi(value)
 	if err != nil {

--- a/common/config.go
+++ b/common/config.go
@@ -1,16 +1,15 @@
 package common
 
 import (
-	uberzap "go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"errors"
 	"strconv"
+	"sync"
+
+	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	corev1 "k8s.io/api/core/v1"
 )
-
-// OpConfig stored operator configuration
-type OpConfig map[string]string
 
 const (
 
@@ -54,7 +53,7 @@ const (
 )
 
 // Config stores operator configuration
-var Config = OpConfig{}
+var Config = &sync.Map{}
 
 var LevelFunc = uberzap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
 	return lvl >= Config.GetZapLogLevel()
@@ -76,37 +75,45 @@ var StackLevelFunc = uberzap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
 })
 
 // LoadFromConfigMap creates a config out of kubernetes config map
-func (oc OpConfig) LoadFromConfigMap(cm *corev1.ConfigMap) {
-	for k, v := range DefaultOpConfig() {
-		oc[k] = v
-	}
-
+func LoadFromConfigMap(oc *sync.Map, cm *corev1.ConfigMap) {
+	cfg := DefaultOpConfig()
+	cfg.Range(func(key, value interface{}) bool {
+		oc.Store(key, value)
+		return true
+	})
 	for k, v := range cm.Data {
-		oc[k] = v
+		oc.Store(k, v)
 	}
 }
-func (oc OpConfig) CheckValidValue(key string, OperatorName string) error {
-	value := oc[key]
+func CheckValidValue(oc *sync.Map, key string, OperatorName string) error {
+	// value := oc[key]
+	value, ok := oc.Load(key)
+	if !ok {
+		return errors.New("operator config could not get value for key: " + key)
+	}
 
-	intValue, err := strconv.Atoi(value)
+	intValue, err := strconv.Atoi(value.(string))
 	if err != nil {
-		oc.SetConfigMapDefaultValue(key)
+		SetConfigMapDefaultValue(oc, key)
 		return errors.New(key + " in ConfigMap: " + OperatorName + " has an invalid syntax, error: " + err.Error())
 	} else if key == OpConfigReconcileIntervalSeconds && intValue <= 0 {
-		oc.SetConfigMapDefaultValue(key)
-		return errors.New(key + " in ConfigMap: " + OperatorName + " is set to " + value + ". It must be greater than 0.")
+		SetConfigMapDefaultValue(oc, key)
+		return errors.New(key + " in ConfigMap: " + OperatorName + " is set to " + value.(string) + ". It must be greater than 0.")
 	} else if key == OpConfigReconcileIntervalPercentage && intValue < 0 {
-		oc.SetConfigMapDefaultValue(key)
-		return errors.New(key + " in ConfigMap: " + OperatorName + " is set to " + value + ". It must be greater than or equal to 0.")
+		SetConfigMapDefaultValue(oc, key)
+		return errors.New(key + " in ConfigMap: " + OperatorName + " is set to " + value.(string) + ". It must be greater than or equal to 0.")
 	}
 
 	return nil
 }
 
 // SetConfigMapDefaultValue sets default value for specified key
-func (oc OpConfig) SetConfigMapDefaultValue(key string) {
+func SetConfigMapDefaultValue(oc *sync.Map, key string) {
 	cm := DefaultOpConfig()
-	oc[key] = cm[key]
+	defaultValue, ok := cm.Load(key)
+	if ok {
+		oc.Store(key, defaultValue)
+	}
 }
 
 // Returns the zap log level corresponding to the value of the
@@ -135,13 +142,12 @@ func (oc OpConfig) GetZapLogLevel() zapcore.Level {
 }
 
 // DefaultOpConfig returns default configuration
-func DefaultOpConfig() OpConfig {
-	cfg := OpConfig{}
-	cfg[OpConfigDefaultHostname] = ""
-	cfg[OpConfigCMCADuration] = "8766h"
-	cfg[OpConfigCMCertDuration] = "2160h"
-	cfg[OpConfigLogLevel] = logLevelInfo
-	cfg[OpConfigReconcileIntervalSeconds] = "15"
-	cfg[OpConfigReconcileIntervalPercentage] = "100"
+func DefaultOpConfig() *sync.Map {
+	cfg := &sync.Map{}
+	cfg.Store(OpConfigDefaultHostname, "")
+	cfg.Store(OpConfigCMCADuration, "8766h")
+	cfg.Store(OpConfigCMCertDuration, "2160h")
+	cfg.Store(OpConfigReconcileIntervalSeconds, "15")
+	cfg.Store(OpConfigReconcileIntervalPercentage, "100")
 	return cfg
 }

--- a/internal/controller/runtimecomponent_controller.go
+++ b/internal/controller/runtimecomponent_controller.go
@@ -124,11 +124,11 @@ func (r *RuntimeComponentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return reconcile.Result{}, err
 	}
 
-	if err = common.Config.CheckValidValue(common.OpConfigReconcileIntervalSeconds, OperatorName); err != nil {
+	if err = common.CheckValidValue(common.Config, common.OpConfigReconcileIntervalSeconds, OperatorName); err != nil {
 		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 	}
 
-	if err = common.Config.CheckValidValue(common.OpConfigReconcileIntervalPercentage, OperatorName); err != nil {
+	if err = common.CheckValidValue(common.Config, common.OpConfigReconcileIntervalPercentage, OperatorName); err != nil {
 		return r.ManageError(err, common.StatusConditionTypeReconciled, instance)
 	}
 

--- a/internal/controller/runtimecomponent_controller.go
+++ b/internal/controller/runtimecomponent_controller.go
@@ -623,7 +623,7 @@ func (r *RuntimeComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}, builder.WithPredicates(predSubResWithGenCheck)).
 		Owns(&autoscalingv1.HorizontalPodAutoscaler{}, builder.WithPredicates(predSubResource)).
 		WithOptions(kcontroller.Options{
-			MaxConcurrentReconciles: 1,
+			MaxConcurrentReconciles: 8,
 		})
 
 	ok, _ := r.IsGroupVersionSupported(routev1.SchemeGroupVersion.String(), "Route")

--- a/internal/controller/runtimecomponent_controller.go
+++ b/internal/controller/runtimecomponent_controller.go
@@ -623,7 +623,7 @@ func (r *RuntimeComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}, builder.WithPredicates(predSubResWithGenCheck)).
 		Owns(&autoscalingv1.HorizontalPodAutoscaler{}, builder.WithPredicates(predSubResource)).
 		WithOptions(kcontroller.Options{
-			MaxConcurrentReconciles: 5,
+			MaxConcurrentReconciles: 1,
 		})
 
 	ok, _ := r.IsGroupVersionSupported(routev1.SchemeGroupVersion.String(), "Route")

--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -198,7 +198,7 @@ func addStatusWarnings(ba common.BaseComponent) {
 }
 
 func getBaseReconcileInterval(s common.BaseComponentStatus) int32 {
-	baseIntervalInt, _ := strconv.Atoi(common.Config[common.OpConfigReconcileIntervalSeconds])
+	baseIntervalInt, _ := strconv.Atoi(common.LoadFromConfig(common.Config, common.OpConfigReconcileIntervalSeconds))
 	baseInterval := int32(baseIntervalInt)
 	s.SetReconcileInterval(&baseInterval)
 
@@ -215,7 +215,7 @@ func resetReconcileInterval(newCondition common.StatusCondition, s common.BaseCo
 
 // Precondition: Operator config values for common.OpConfigReconcileIntervalSeconds and common.OpConfigReconcileIntervalPercentage must be integers
 func updateReconcileInterval(maxSeconds int, oldCondition common.StatusCondition, newCondition common.StatusCondition, s common.BaseComponentStatus) time.Duration {
-	oldReconcileInterval := float64(*s.GetReconcileInterval())
+	var oldReconcileInterval int32
 
 	var newCount int32
 	count := oldCondition.GetUnchangedConditionCount()

--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -237,10 +237,7 @@ func updateReconcileInterval(maxSeconds int, oldCondition common.StatusCondition
 		if err != nil {
 			return defaultReconcileInterval
 		}
-		intervalIncreasePercentage, err := strconv.ParseFloat(reconcileIntervalPercentage, 64)
-		if err != nil {
-			return defaultReconcileInterval
-		}
+		intervalIncreasePercentage, _ := strconv.ParseFloat(reconcileIntervalPercentage, 64)
 		exp := float64(newCount / 2)
 		increase := math.Pow(1+(intervalIncreasePercentage/100), exp)
 
@@ -248,10 +245,7 @@ func updateReconcileInterval(maxSeconds int, oldCondition common.StatusCondition
 		if err != nil {
 			return defaultReconcileInterval
 		}
-		baseInterval, err := strconv.ParseFloat(reconcileIntervalSeconds, 64)
-		if err != nil {
-			return defaultReconcileInterval
-		}
+		baseInterval, _ := strconv.ParseFloat(reconcileIntervalSeconds, 64)
 		newInterval := int32(baseInterval * increase)
 
 		// Only increase to the maximum interval

--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -518,10 +518,7 @@ func (r *ReconcilerBase) GenerateCMIssuer(namespace string, prefix string, CACom
 			Name: prefix + "-self-signed",
 		}
 
-		var duration time.Duration
-		var err error
-		cmCADuration := common.LoadFromConfig(common.Config, common.OpConfigCMCADuration)
-		duration, err = time.ParseDuration(cmCADuration)
+		duration, err := time.ParseDuration(common.LoadFromConfig(common.Config, common.OpConfigCMCADuration))
 		if err != nil {
 			return err
 		}
@@ -698,10 +695,7 @@ func (r *ReconcilerBase) GenerateSvcCertSecret(ba common.BaseComponent, prefix s
 
 			svcCert.Spec.SecretName = svcCertSecretName
 
-			var duration time.Duration
-			var err error
-			cmCertDuration := common.LoadFromConfig(common.Config, common.OpConfigCMCertDuration)
-			duration, err = time.ParseDuration(cmCertDuration)
+			duration, err := time.ParseDuration(common.LoadFromConfig(common.Config, common.OpConfigCMCertDuration))
 			if err != nil {
 				return err
 			}

--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -515,9 +515,13 @@ func (r *ReconcilerBase) GenerateCMIssuer(namespace string, prefix string, CACom
 			Name: prefix + "-self-signed",
 		}
 
-		duration, err := time.ParseDuration(common.Config[common.OpConfigCMCADuration])
-		if err != nil {
-			return err
+		var duration time.Duration
+		var err error
+		if cmCADuration, found := common.Config.Load(common.OpConfigCMCADuration); found {
+			duration, err = time.ParseDuration(cmCADuration.(string))
+			if err != nil {
+				return err
+			}
 		}
 		caCert.Spec.Duration = &metav1.Duration{Duration: duration}
 		return nil
@@ -691,9 +695,13 @@ func (r *ReconcilerBase) GenerateSvcCertSecret(ba common.BaseComponent, prefix s
 
 			svcCert.Spec.SecretName = svcCertSecretName
 
-			duration, err := time.ParseDuration(common.Config[common.OpConfigCMCertDuration])
-			if err != nil {
-				return err
+			var duration time.Duration
+			var err error
+			if cmCertDuration, found := common.Config.Load(common.OpConfigCMCertDuration); found {
+				duration, err = time.ParseDuration(cmCertDuration.(string))
+				if err != nil {
+					return err
+				}
 			}
 			svcCert.Spec.Duration = &metav1.Duration{Duration: duration}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -116,10 +116,9 @@ func CustomizeRoute(route *routev1.Route, ba common.BaseComponent, key string, c
 		route.Annotations = MergeMaps(route.Annotations, rt.GetAnnotations())
 
 		host := rt.GetHost()
-		if defaultHostName, found := common.Config.Load(common.OpConfigDefaultHostname); found {
-			if host == "" && defaultHostName.(string) != "" {
-				host = obj.GetName() + "-" + obj.GetNamespace() + "." + defaultHostName.(string)
-			}
+		defaultHostName := common.LoadFromConfig(common.Config, common.OpConfigDefaultHostname)
+		if host == "" && defaultHostName != "" {
+			host = obj.GetName() + "-" + obj.GetNamespace() + "." + defaultHostName
 		}
 
 		ba.GetStatus().SetReference(common.StatusReferenceRouteHost, host)
@@ -1441,10 +1440,9 @@ func CustomizeIngress(ing *networkingv1.Ingress, ba common.BaseComponent) {
 	if ba.GetService().GetPortName() != "" {
 		servicePort = ba.GetService().GetPortName()
 	}
-	if defaultHostName, found := common.Config.Load(common.OpConfigDefaultHostname); found {
-		if host == "" && defaultHostName.(string) != "" {
-			host = obj.GetName() + "-" + obj.GetNamespace() + "." + defaultHostName.(string)
-		}
+	defaultHostName := common.LoadFromConfig(common.Config, common.OpConfigDefaultHostname)
+	if host == "" && defaultHostName != "" {
+		host = obj.GetName() + "-" + obj.GetNamespace() + "." + defaultHostName
 	}
 
 	if host == "" {
@@ -1885,10 +1883,9 @@ func ShouldDeleteRoute(ba common.BaseComponent) bool {
 		// The host was previously set.
 		// If the host is now empty, delete the old route
 		rt := ba.GetRoute()
-		if defaultHostName, found := common.Config.Load(common.OpConfigDefaultHostname); found {
-			if rt == nil || (rt.GetHost() == "" && defaultHostName.(string) == "") {
-				return true
-			}
+		defaultHostName := common.LoadFromConfig(common.Config, common.OpConfigDefaultHostname)
+		if rt == nil || (rt.GetHost() == "" && defaultHostName == "") {
+			return true
 		}
 	}
 	return false

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -783,7 +783,7 @@ func TestShouldDeleteRoute(t *testing.T) {
 
 	// When there is a defaultHost in config.
 	// This should be ignored as the route is nil
-	common.Config[common.OpConfigDefaultHostname] = "default.host"
+	common.Config.Store(common.OpConfigDefaultHostname, "default.host")
 	noPreviousWithDefault := ShouldDeleteRoute(runtime)
 
 	// If the route object exists with no host,

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -110,6 +110,12 @@ type Test struct {
 	actual   interface{}
 }
 
+func TestMain(m *testing.M) {
+	common.Config = common.DefaultOpConfig()
+	rc := m.Run()
+	os.Exit(rc)
+}
+
 func TestCustomizeRoute(t *testing.T) {
 	logger := zap.New()
 	logf.SetLogger(logger)


### PR DESCRIPTION
**What this PR does / why we need it?**:

- This change allows extending operators to set `MaxConcurrentReconciles` to a value greater than `1` by making the Operator ConfigMap thread-safe.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
