### PR TITLE
Set operator log level to info by default

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -157,6 +157,7 @@ func DefaultOpConfig() *sync.Map {
 	cfg.Store(OpConfigDefaultHostname, "")
 	cfg.Store(OpConfigCMCADuration, "8766h")
 	cfg.Store(OpConfigCMCertDuration, "2160h")
+	cfg.Store(OpConfigLogLevel, logLevelInfo)
 	cfg.Store(OpConfigReconcileIntervalSeconds, "15")
 	cfg.Store(OpConfigReconcileIntervalPercentage, "100")
 	return cfg


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Set the operator log level by default to info in the operator's configmap. It was removed in a prior commit but is needed (when the log level is set to fine/finer/finest and removed later on).

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
