### PR TITLE
Remove HorizontalPodAutoscaler from owned and watched resources

### DIFF
--- a/internal/controller/runtimecomponent_controller.go
+++ b/internal/controller/runtimecomponent_controller.go
@@ -623,7 +623,6 @@ func (r *RuntimeComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}, builder.WithPredicates(predSubResource)).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(predSubResWithGenCheck)).
 		Owns(&appsv1.StatefulSet{}, builder.WithPredicates(predSubResWithGenCheck)).
-		Owns(&autoscalingv1.HorizontalPodAutoscaler{}, builder.WithPredicates(predSubResource)).
 		WithOptions(kcontroller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,
 		})

--- a/internal/controller/runtimecomponent_controller.go
+++ b/internal/controller/runtimecomponent_controller.go
@@ -618,7 +618,7 @@ func (r *RuntimeComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	b := ctrl.NewControllerManagedBy(mgr).For(&appstacksv1.RuntimeComponent{}, builder.WithPredicates(pred))
 
-	if !appstacksutils.GetOperatorDisableWatch() {
+	if !appstacksutils.GetOperatorDisableWatches() {
 		b = b.Owns(&corev1.Service{}, builder.WithPredicates(predSubResource)).
 			Owns(&corev1.Secret{}, builder.WithPredicates(predSubResource)).
 			Owns(&appsv1.Deployment{}, builder.WithPredicates(predSubResWithGenCheck)).

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1917,8 +1917,8 @@ func GetOperatorWatchHPA() bool {
 }
 
 // Returns the env setting for disabling all watches
-func GetOperatorDisableWatch() bool {
-	return parseEnvAsBool(os.Getenv("OPERATOR_DISABLE_WATCH"))
+func GetOperatorDisableWatches() bool {
+	return parseEnvAsBool(os.Getenv("OPERATOR_DISABLE_WATCHES"))
 }
 
 // Parses env as bool or returns false on failure

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1910,3 +1910,24 @@ func parseEnvAsPositiveInt(envValue string) int {
 	}
 	return -1
 }
+
+// Returns the env setting for Operator watching HorizontalPodAutoscaler (HPA)
+func GetOperatorWatchHPA() bool {
+	return parseEnvAsBool(os.Getenv("OPERATOR_WATCH_HPA"))
+}
+
+// Returns the env setting for disabling all watches
+func GetOperatorDisableWatch() bool {
+	return parseEnvAsBool(os.Getenv("OPERATOR_DISABLE_WATCH"))
+}
+
+// Parses env as bool or returns false on failure
+func parseEnvAsBool(envValue string) bool {
+	if envValue != "" {
+		boolVal, err := strconv.ParseBool(envValue)
+		if err == nil {
+			return boolVal
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Remove the watch on HorizontalPodAutoscaler (HPA) as the frequent updates (statistics) of HPA cause the reconcile queue to be filled up and result in the delay of other necessary reconciles
- add options to control watch

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
