### PR TITLE
Optimize cert generation by delaying create/update requests

### DIFF
--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -485,6 +485,51 @@ func (r *ReconcilerBase) GetRouteTLSValues(ba common.BaseComponent) (key string,
 	return key, cert, ca, destCa, nil
 }
 
+func (r *ReconcilerBase) checkCertificateReady(cert *certmanagerv1.Certificate) error {
+	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, cert)
+	if err != nil {
+		return err
+	}
+	isReady := false
+	for _, condition := range cert.Status.Conditions {
+		if condition.Type == certmanagerv1.CertificateConditionReady {
+			if condition.Status == certmanagermetav1.ConditionTrue {
+				isReady = true
+			}
+		}
+	}
+	if !isReady {
+		return fmt.Errorf("certificate %s is not ready", cert.Name)
+	}
+	return nil
+}
+
+func (r *ReconcilerBase) checkIssuerReady(issuer *certmanagerv1.Issuer) error {
+	err := r.GetClient().Get(context.TODO(), types.NamespacedName{Name: issuer.Name, Namespace: issuer.Namespace}, issuer)
+	if err != nil {
+		return err
+	}
+	isReady := false
+	for _, condition := range issuer.Status.Conditions {
+		if condition.Type == certmanagerv1.IssuerConditionReady {
+			if condition.Status == certmanagermetav1.ConditionTrue {
+				isReady = true
+			}
+		}
+	}
+	if !isReady {
+		return fmt.Errorf("issuer %s is not ready", issuer.Name)
+	}
+	return nil
+}
+
+func (r *ReconcilerBase) checkSecretExists(secretName, secretNamespace string) error {
+	secret := &corev1.Secret{}
+	secret.Name = secretName
+	secret.Namespace = secretNamespace
+	return r.GetClient().Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: secretNamespace}, secret)
+}
+
 func (r *ReconcilerBase) GenerateCMIssuer(namespace string, prefix string, CACommonName string, operatorName string) error {
 	if ok, err := r.IsGroupVersionSupported(certmanagerv1.SchemeGroupVersion.String(), "Issuer"); err != nil {
 		return err
@@ -504,16 +549,21 @@ func (r *ReconcilerBase) GenerateCMIssuer(namespace string, prefix string, CACom
 	if err != nil {
 		return err
 	}
+	if err := r.checkIssuerReady(issuer); err != nil {
+		return err
+	}
+
 	caCert := &certmanagerv1.Certificate{ObjectMeta: metav1.ObjectMeta{
 		Name:      prefix + "-ca-cert",
 		Namespace: namespace,
 	}}
 
+	caCertSecretName := prefix + "-ca-tls"
 	err = r.CreateOrUpdate(caCert, nil, func() error {
 		caCert.Labels = MergeMaps(caCert.Labels, map[string]string{"app.kubernetes.io/managed-by": operatorName})
 		caCert.Spec.CommonName = CACommonName
 		caCert.Spec.IsCA = true
-		caCert.Spec.SecretName = prefix + "-ca-tls"
+		caCert.Spec.SecretName = caCertSecretName
 		caCert.Spec.IssuerRef = certmanagermetav1.ObjectReference{
 			Name: prefix + "-self-signed",
 		}
@@ -530,6 +580,7 @@ func (r *ReconcilerBase) GenerateCMIssuer(namespace string, prefix string, CACom
 	if err != nil {
 		return err
 	}
+
 	CustomCACert := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 		Name:      prefix + "-custom-ca-tls",
 		Namespace: namespace,
@@ -539,6 +590,14 @@ func (r *ReconcilerBase) GenerateCMIssuer(namespace string, prefix string, CACom
 		Namespace: CustomCACert.GetNamespace()}, CustomCACert)
 	if err == nil {
 		customCACertFound = true
+	} else {
+		// check CA Certificate and it's Secret exist before CA Issuer init
+		if err := r.checkCertificateReady(caCert); err != nil {
+			return err
+		}
+		if err := r.checkSecretExists(caCertSecretName, namespace); err != nil {
+			return err
+		}
 	}
 
 	issuer = &certmanagerv1.Issuer{ObjectMeta: metav1.ObjectMeta{
@@ -548,7 +607,7 @@ func (r *ReconcilerBase) GenerateCMIssuer(namespace string, prefix string, CACom
 	err = r.CreateOrUpdate(issuer, nil, func() error {
 		issuer.Labels = MergeMaps(issuer.Labels, map[string]string{"app.kubernetes.io/managed-by": operatorName})
 		issuer.Spec.CA = &certmanagerv1.CAIssuer{}
-		issuer.Spec.CA.SecretName = prefix + "-ca-tls"
+		issuer.Spec.CA.SecretName = caCertSecretName
 		if issuer.Annotations == nil {
 			issuer.Annotations = map[string]string{}
 		}
@@ -574,7 +633,6 @@ func (r *ReconcilerBase) GenerateCMIssuer(namespace string, prefix string, CACom
 }
 
 func (r *ReconcilerBase) GenerateSvcCertSecret(ba common.BaseComponent, prefix string, CACommonName string, operatorName string) (bool, error) {
-
 	delete(ba.GetStatus().GetReferences(), common.StatusReferenceCertSecretName)
 	cleanup := func() {
 		if ok, err := r.IsGroupVersionSupported(certmanagerv1.SchemeGroupVersion.String(), "Certificate"); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Speeds up the time to load certificates by waiting for Secrets to exist in the cluster before requesting the remaining certificate chain.
- As demonstrated in past test runs, overwhelming cert manager with certificate create request when dependent resources are not yet accessible leads to slowing down of the cert generation process. This will help limit frequent re-queuing for cert manager operator.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
