### PR TITLE
Fix empty readiness probe failures for Knative

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -977,28 +977,19 @@ func CustomizeKnativeService(ksvc *servingv1.Service, ba common.BaseComponent) {
 
 	if ksvc.Spec.Template.Spec.Containers[0].LivenessProbe != nil {
 		if ksvc.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet != nil {
-			ksvc.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port = intstr.IntOrString{}
-		}
-		if ksvc.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket != nil {
-			ksvc.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket.Port = intstr.IntOrString{}
+			ksvc.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Scheme = ""
 		}
 	}
 
 	if ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe != nil {
 		if ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet != nil {
-			ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.IntOrString{}
-		}
-		if ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket != nil {
-			ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port = intstr.IntOrString{}
+			ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Scheme = ""
 		}
 	}
 
 	if ksvc.Spec.Template.Spec.Containers[0].StartupProbe != nil {
 		if ksvc.Spec.Template.Spec.Containers[0].StartupProbe.HTTPGet != nil {
-			ksvc.Spec.Template.Spec.Containers[0].StartupProbe.HTTPGet.Port = intstr.IntOrString{}
-		}
-		if ksvc.Spec.Template.Spec.Containers[0].StartupProbe.TCPSocket != nil {
-			ksvc.Spec.Template.Spec.Containers[0].StartupProbe.TCPSocket.Port = intstr.IntOrString{}
+			ksvc.Spec.Template.Spec.Containers[0].StartupProbe.HTTPGet.Scheme = ""
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Fixes empty readiness probe failures for Knative
- Removes unsetting port and unsets scheme

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
https://github.com/WASdev/websphere-liberty-operator/issues/400