### PR TITLE
Ensure Ready status first

### DIFF
--- a/api/v1/runtimecomponent_types.go
+++ b/api/v1/runtimecomponent_types.go
@@ -1223,62 +1223,26 @@ func (s *RuntimeComponentStatus) GetCondition(t common.StatusConditionType) comm
 // SetCondition sets status condition
 func (s *RuntimeComponentStatus) SetCondition(c common.StatusCondition) {
     condition := &StatusCondition{}
-    found := false
-    readyUpdated := c.GetType() == common.StatusConditionTypeReady
-    
-    for i := range s.Conditions {
-        if s.Conditions[i].GetType() == c.GetType() {
-            condition = &s.Conditions[i]
-            found = true
-            break
-        }
-    }
+	found := false
+	for i := range s.Conditions {
+		if s.Conditions[i].GetType() == c.GetType() {
+			condition = &s.Conditions[i]
+			found = true
+			break
+		}
+	}
 
-    if condition.GetStatus() != c.GetStatus() || condition.GetMessage() != c.GetMessage() || condition.GetReason() != c.GetReason() {
-        condition.SetLastTransitionTime(&metav1.Time{Time: time.Now()})
-    }
+	if condition.GetStatus() != c.GetStatus() || condition.GetMessage() != c.GetMessage() || condition.GetReason() != c.GetReason() {
+		condition.SetLastTransitionTime(&metav1.Time{Time: time.Now()})
+	}
 
-    condition.SetReason(c.GetReason())
-    condition.SetMessage(c.GetMessage())
-    condition.SetStatus(c.GetStatus())
-    condition.SetType(c.GetType())
-
-    if !found {
-        if readyUpdated {
-            // New Ready condition - prepend it
-            s.Conditions = append([]StatusCondition{*condition}, s.Conditions...)
-        } else {
-            // New non-Ready condition - append it
-            s.Conditions = append(s.Conditions, *condition)
-        }
-    } else if readyUpdated && len(s.Conditions) > 1 {
-        // Existing Ready condition was updated - move it to front
-        // First, find the Ready condition index
-        readyIndex := -1
-        for i := range s.Conditions {
-            if s.Conditions[i].GetType() == common.StatusConditionTypeReady {
-                readyIndex = i
-                break
-            }
-        }
-        
-        // Only reorder if Ready isn't already first
-        if readyIndex > 0 {
-            // Create a new slice with Ready first
-            newConditions := make([]StatusCondition, len(s.Conditions))
-            newConditions[0] = s.Conditions[readyIndex]
-            
-            // Copy conditions before Ready
-            copy(newConditions[1:readyIndex+1], s.Conditions[:readyIndex])
-            
-            // Copy conditions after Ready
-            if readyIndex < len(s.Conditions)-1 {
-                copy(newConditions[readyIndex+1:], s.Conditions[readyIndex+1:])
-            }
-            
-            s.Conditions = newConditions
-        }
-    }
+	condition.SetReason(c.GetReason())
+	condition.SetMessage(c.GetMessage())
+	condition.SetStatus(c.GetStatus())
+	condition.SetType(c.GetType())
+	if !found {
+		s.Conditions = append(s.Conditions, *condition)
+	}
 }
 
 func (s *RuntimeComponentStatus) UnsetCondition(c common.StatusCondition) {

--- a/api/v1/runtimecomponent_types.go
+++ b/api/v1/runtimecomponent_types.go
@@ -1222,27 +1222,63 @@ func (s *RuntimeComponentStatus) GetCondition(t common.StatusConditionType) comm
 
 // SetCondition sets status condition
 func (s *RuntimeComponentStatus) SetCondition(c common.StatusCondition) {
-	condition := &StatusCondition{}
-	found := false
-	for i := range s.Conditions {
-		if s.Conditions[i].GetType() == c.GetType() {
-			condition = &s.Conditions[i]
-			found = true
-			break
-		}
-	}
+    condition := &StatusCondition{}
+    found := false
+    readyUpdated := c.GetType() == common.StatusConditionTypeReady
+    
+    for i := range s.Conditions {
+        if s.Conditions[i].GetType() == c.GetType() {
+            condition = &s.Conditions[i]
+            found = true
+            break
+        }
+    }
 
-	if condition.GetStatus() != c.GetStatus() || condition.GetMessage() != c.GetMessage() || condition.GetReason() != c.GetReason() {
-		condition.SetLastTransitionTime(&metav1.Time{Time: time.Now()})
-	}
+    if condition.GetStatus() != c.GetStatus() || condition.GetMessage() != c.GetMessage() || condition.GetReason() != c.GetReason() {
+        condition.SetLastTransitionTime(&metav1.Time{Time: time.Now()})
+    }
 
-	condition.SetReason(c.GetReason())
-	condition.SetMessage(c.GetMessage())
-	condition.SetStatus(c.GetStatus())
-	condition.SetType(c.GetType())
-	if !found {
-		s.Conditions = append(s.Conditions, *condition)
-	}
+    condition.SetReason(c.GetReason())
+    condition.SetMessage(c.GetMessage())
+    condition.SetStatus(c.GetStatus())
+    condition.SetType(c.GetType())
+
+    if !found {
+        if readyUpdated {
+            // New Ready condition - prepend it
+            s.Conditions = append([]StatusCondition{*condition}, s.Conditions...)
+        } else {
+            // New non-Ready condition - append it
+            s.Conditions = append(s.Conditions, *condition)
+        }
+    } else if readyUpdated && len(s.Conditions) > 1 {
+        // Existing Ready condition was updated - move it to front
+        // First, find the Ready condition index
+        readyIndex := -1
+        for i := range s.Conditions {
+            if s.Conditions[i].GetType() == common.StatusConditionTypeReady {
+                readyIndex = i
+                break
+            }
+        }
+        
+        // Only reorder if Ready isn't already first
+        if readyIndex > 0 {
+            // Create a new slice with Ready first
+            newConditions := make([]StatusCondition, len(s.Conditions))
+            newConditions[0] = s.Conditions[readyIndex]
+            
+            // Copy conditions before Ready
+            copy(newConditions[1:readyIndex+1], s.Conditions[:readyIndex])
+            
+            // Copy conditions after Ready
+            if readyIndex < len(s.Conditions)-1 {
+                copy(newConditions[readyIndex+1:], s.Conditions[readyIndex+1:])
+            }
+            
+            s.Conditions = newConditions
+        }
+    }
 }
 
 func (s *RuntimeComponentStatus) UnsetCondition(c common.StatusCondition) {

--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -308,12 +308,12 @@ func (r *ReconcilerBase) sanitizeReadyFirst(ba common.BaseComponent) {
 		return
 	}
 
-	var readyCondition common.StatusCondition
+	var ready common.StatusCondition
 	readyIndex := -1
 
 	for i, condition := range conditions {
 		if condition.GetType() == common.StatusConditionTypeReady {
-			readyCondition = condition
+			ready = condition
 			readyIndex = i
 			break
 		}
@@ -335,6 +335,8 @@ func (r *ReconcilerBase) sanitizeReadyFirst(ba common.BaseComponent) {
 
 			rcs.Conditions = newConditions
 		}
+		status.UnsetCondition(ready)
+		status.SetCondition(ready)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Guarantees Ready always exists and is first in `.status.conditions` by initialising during reconcile and normalising order
- Aligns ManageSuccess / ManageError status updates for reads in OLO/WLO 

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
https://github.com/OpenLiberty/open-liberty-operator/issues/724