### PR TITLE
Ready status priority

### DIFF
--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -371,6 +371,10 @@ func (r *ReconcilerBase) ManageError(issue error, conditionType common.StatusCon
 		maxSeconds := getMaxReconcileInterval(false)
 		retryInterval = updateReconcileInterval(maxSeconds, s, ba)
 	}
+	
+	// Ensure Ready condition exists before updating status
+	r.ensureReadyExists(ba)
+	r.sanitizeReadyFirst(ba)
 
 	err := r.UpdateStatus(obj)
 	if err != nil {
@@ -429,6 +433,10 @@ func (r *ReconcilerBase) ManageSuccess(conditionType common.StatusConditionType,
 			retryInterval = updateReconcileInterval(maxSeconds, s, ba)
 		}
 	}
+	
+	// Ensure Ready condition exists before updating status
+	r.ensureReadyExists(ba)
+	r.sanitizeReadyFirst(ba)
 
 	err := r.UpdateStatus(ba.(client.Object))
 	if err != nil {

--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -12,6 +12,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 
 	"github.com/application-stacks/runtime-component-operator/common"
+	v1 "github.com/application-stacks/runtime-component-operator/api/v1"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	routev1 "github.com/openshift/api/route/v1"

--- a/utils/reconciler.go
+++ b/utils/reconciler.go
@@ -280,6 +280,51 @@ func updateReconcileInterval(maxSeconds int, s common.BaseComponentStatus, ba co
 	return time.Duration(newInterval) * time.Second
 }
 
+func (r *ReconcilerBase) ensureReadyExists(ba common.BaseComponent) {
+	status := ba.GetStatus()
+
+	readyExists := false
+	for _, condition := range status.GetConditions() {
+		if condition.GetType() == common.StatusConditionTypeReady {
+			readyExists = true
+			break
+		}
+	}
+
+	if !readyExists {
+		readyCondition := status.NewCondition(common.StatusConditionTypeReady)
+		readyCondition.SetStatus(corev1.ConditionFalse)
+		readyCondition.SetReason("Reconciling")
+		readyCondition.SetMessage("Application is being reconciled")
+		readyCondition.SetLastTransitionTime(&metav1.Time{Time: time.Now()})
+		status.SetCondition(readyCondition)
+	}
+}
+
+func (r *ReconcilerBase) sanitizeReadyFirst(ba common.BaseComponent) {
+	status := ba.GetStatus()
+	rcs, ok := status.(*v1.RuntimeComponentStatus)
+	if !ok || len(rcs.Conditions) <= 1 {
+		return
+	}
+
+	var ready v1.StatusCondition
+	var others []v1.StatusCondition
+	for _, c := range rcs.Conditions {
+		if c.GetType() == common.StatusConditionTypeReady {
+			ready = c
+		} else {
+			others = append(others, c)
+		}
+	}
+
+	if ready.GetType() == "" || rcs.Conditions[0].GetType() == common.StatusConditionTypeReady {
+        return
+    }
+
+	rcs.Conditions = append([]v1.StatusCondition{ready}, others...)
+}
+
 // ManageError ...
 func (r *ReconcilerBase) ManageError(issue error, conditionType common.StatusConditionType, ba common.BaseComponent) (reconcile.Result, error) {
 	s := ba.GetStatus()


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Guarantees Ready always exists and is first in `.status.conditions` by initialising during reconcile and normalising order
- Aligns ManageSuccess / ManageError status updates for reads in OLO/WLO 

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
https://github.com/OpenLiberty/open-liberty-operator/issues/724