### PR TITLE
Ignore secrets baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,3 @@ tags
 .idea
 # To allow the file to be copied into this repo during a build
 rco.secrets.baseline
-#


### PR DESCRIPTION
So that it can be copied into the source tree during a build
