### PR TITLE
Clear MP default httpGet probe handler

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -64,9 +64,17 @@ func CustomizeProbeDefaults(config *corev1.Probe, defaultProbe *corev1.Probe) *c
 	probe := defaultProbe
 	if config.ProbeHandler.Exec != nil {
 		probe.ProbeHandler.Exec = config.ProbeHandler.Exec
+		// clear remaining handlers
+		probe.ProbeHandler.GRPC = nil
+		probe.ProbeHandler.HTTPGet = nil
+		probe.ProbeHandler.TCPSocket = nil
 	}
 	if config.ProbeHandler.GRPC != nil {
 		probe.ProbeHandler.GRPC = config.ProbeHandler.GRPC
+		// clear remaining handlers
+		probe.ProbeHandler.Exec = nil
+		probe.ProbeHandler.HTTPGet = nil
+		probe.ProbeHandler.TCPSocket = nil
 	}
 	if config.ProbeHandler.HTTPGet != nil {
 		if probe.ProbeHandler.HTTPGet == nil {
@@ -85,9 +93,17 @@ func CustomizeProbeDefaults(config *corev1.Probe, defaultProbe *corev1.Probe) *c
 		if len(config.ProbeHandler.HTTPGet.HTTPHeaders) > 0 {
 			probe.ProbeHandler.HTTPGet.HTTPHeaders = config.ProbeHandler.HTTPGet.HTTPHeaders
 		}
+		// clear remaining handlers
+		probe.ProbeHandler.Exec = nil
+		probe.ProbeHandler.GRPC = nil
+		probe.ProbeHandler.TCPSocket = nil
 	}
 	if config.ProbeHandler.TCPSocket != nil {
 		probe.ProbeHandler.TCPSocket = config.ProbeHandler.TCPSocket
+		// clear remaining handlers
+		probe.ProbeHandler.Exec = nil
+		probe.ProbeHandler.GRPC = nil
+		probe.ProbeHandler.HTTPGet = nil
 	}
 	if config.InitialDelaySeconds != 0 {
 		probe.InitialDelaySeconds = config.InitialDelaySeconds

--- a/common/common.go
+++ b/common/common.go
@@ -68,15 +68,13 @@ func CustomizeProbeDefaults(config *corev1.Probe, defaultProbe *corev1.Probe) *c
 		probe.ProbeHandler.GRPC = nil
 		probe.ProbeHandler.HTTPGet = nil
 		probe.ProbeHandler.TCPSocket = nil
-	}
-	if config.ProbeHandler.GRPC != nil {
+	} else if config.ProbeHandler.GRPC != nil {
 		probe.ProbeHandler.GRPC = config.ProbeHandler.GRPC
 		// clear remaining handlers
 		probe.ProbeHandler.Exec = nil
 		probe.ProbeHandler.HTTPGet = nil
 		probe.ProbeHandler.TCPSocket = nil
-	}
-	if config.ProbeHandler.HTTPGet != nil {
+	} else if config.ProbeHandler.HTTPGet != nil {
 		if probe.ProbeHandler.HTTPGet == nil {
 			probe.ProbeHandler.HTTPGet = &corev1.HTTPGetAction{}
 		}
@@ -97,8 +95,7 @@ func CustomizeProbeDefaults(config *corev1.Probe, defaultProbe *corev1.Probe) *c
 		probe.ProbeHandler.Exec = nil
 		probe.ProbeHandler.GRPC = nil
 		probe.ProbeHandler.TCPSocket = nil
-	}
-	if config.ProbeHandler.TCPSocket != nil {
+	} else if config.ProbeHandler.TCPSocket != nil {
 		probe.ProbeHandler.TCPSocket = config.ProbeHandler.TCPSocket
 		// clear remaining handlers
 		probe.ProbeHandler.Exec = nil


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Fixes issue with MicroProfile default httpGet handler not being cleared when user configures a probe handler in the CR spec. 
- Since only one probe handler should be set anyways, we can exit early after processing the first probe handler configured in the CR spec using `else if` checks.

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
