### PR TITLE
fix: preserve user-defined `app.kubernetes.io/part-of` label

### DIFF
--- a/api/v1/runtimecomponent_types.go
+++ b/api/v1/runtimecomponent_types.go
@@ -1136,7 +1136,9 @@ func (cr *RuntimeComponent) Initialize() {
 	}
 
 	if cr.Labels != nil {
-		cr.Labels["app.kubernetes.io/part-of"] = cr.Spec.ApplicationName
+		if _, found := cr.Labels["app.kubernetes.io/part-of"]; !found {
+			cr.Labels["app.kubernetes.io/part-of"] = cr.Spec.ApplicationName
+		}
 	}
 
 	// This is to handle when there is no service in the CR


### PR DESCRIPTION
**What this PR does / why we need it?**:

Previously, the Initialize() method unconditionally overwrote the app.kubernetes.io/part-of label with spec.applicationName, even when users explicitly set a custom value in metadata.labels.

Now checks if the label exists before setting it, respecting user-provided values while still defaulting to spec.applicationName when the label is not present.


**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [ ] User guide
- [ ] `CHANGELOG.md`

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #
